### PR TITLE
Add properties.yml to site-level.  Add stub files if they don't exist.  Order README generation according to file merge order.

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -883,7 +883,7 @@ update:
   update_watch_time: 1000-60000
   max_in_flight: 1
 EOF
-	for file in networks resource-pools jobs; do
+	for file in networks resource-pools jobs properties; do
 		cat > ${DEPLOYMENT_ROOT}/${site}/site/${file}.yml <<EOF
 --- {}
 EOF
@@ -935,7 +935,7 @@ create_bosh_init_site() {
 ---
 disk_pools: []
 EOF
-	for file in networks resource-pools jobs; do
+	for file in networks resource-pools jobs properties; do
 		cat > ${DEPLOYMENT_ROOT}/${site}/site/${file}.yml <<EOF
 --- {}
 EOF
@@ -1114,7 +1114,7 @@ EOF
 	done
 }
 
-ensure_normal_files() {
+ensure_normal_build_files() {
     ensure_yaml_files \
 		.global/jobs.yml \
 		.global/deployment.yml \
@@ -1143,7 +1143,7 @@ build_normal_manifest() {
 	(cd ${DEPLOYMENT_ENV_DIR}
 	 spruce $SPRUCE_OPTS merge --prune meta \
         .begin.yml \
-        $(ensure_normal_files)
+        $(ensure_normal_build_files)
      )
 
 	rc=$?
@@ -1156,19 +1156,25 @@ build_normal_manifest() {
 	fi
 }
 
-build_microbosh_manifest() {
-	must_be_in_an_environment
-	need_command spruce
-
-	(cd ${DEPLOYMENT_ENV_DIR}
-	 spruce $SPRUCE_OPTS merge --prune meta \
+ensure_microbosh_build_files() {
+    ensure_yaml_files \
 		.global/deployment.yml \
 		.site/infra.yml \
 		.site/scaling.yml \
 		infra.yml \
 		scaling.yml \
 		director.yml \
-		name.yml)
+		name.yml
+}
+
+build_microbosh_manifest() {
+	must_be_in_an_environment
+	need_command spruce
+
+	(cd ${DEPLOYMENT_ENV_DIR}
+	 spruce $SPRUCE_OPTS merge --prune meta \
+        $(ensure_microbosh_build_files)
+	 )
 
 	if [[ $? != 0 ]]; then
 		echo >&2 "Failed to merge templates; bailing..."
@@ -1221,13 +1227,8 @@ EOF
 	done
 }
 
-build_bosh_init_manifest() {
-	must_be_in_an_environment
-	need_command spruce
-
-	bosh_init_site_metadata > ${DEPLOYMENT_ENV_DIR}/.begin.yml
-	(cd ${DEPLOYMENT_ENV_DIR}
-	 spruce $SPRUCE_OPTS merge --prune meta \
+ensure_bosh_init_build_files() {
+    ensure_yaml_files \
 		.begin.yml \
 		.global/jobs.yml \
 		.global/deployment.yml \
@@ -1240,7 +1241,18 @@ build_bosh_init_manifest() {
 		networking.yml \
 		properties.yml \
 		credentials.yml \
-		name.yml)
+		name.yml
+}
+
+build_bosh_init_manifest() {
+	must_be_in_an_environment
+	need_command spruce
+
+	bosh_init_site_metadata > ${DEPLOYMENT_ENV_DIR}/.begin.yml
+	(cd ${DEPLOYMENT_ENV_DIR}
+	 spruce $SPRUCE_OPTS merge --prune meta \
+        $(ensure_bosh_init_build_files)
+     )
 	rc=$?
 
 	rm -f ${DEPLOYMENT_ENV_DIR}/.begin.yml

--- a/bin/genesis
+++ b/bin/genesis
@@ -101,7 +101,7 @@ setup() {
 
 ensure_yaml_files() {
   for i in $*; do
-    [ ! -f $i ] && echo "--- {}" > $1
+    [ ! -f $i ] && echo "--- {}" > $i
     echo $i
     shift
   done

--- a/bin/genesis
+++ b/bin/genesis
@@ -99,6 +99,13 @@ setup() {
 	DEPLOYMENT_ENV_DIR="${DEPLOYMENT_ROOT}/${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}"
 }
 
+ensure_yaml_files() {
+  for i in $*; do
+    [ ! -f $i ] && echo "--- {}" > $1
+    echo $i
+    shift
+  done
+}
 
 ####################################################
 # checks and validating functions
@@ -1107,14 +1114,8 @@ EOF
 	done
 }
 
-build_normal_manifest() {
-	must_be_in_an_environment
-	need_command spruce
-
-	normal_site_metadata > ${DEPLOYMENT_ENV_DIR}/.begin.yml
-	(cd ${DEPLOYMENT_ENV_DIR}
-	 spruce $SPRUCE_OPTS merge --prune meta \
-		.begin.yml \
+ensure_normal_files() {
+    ensure_yaml_files \
 		.global/jobs.yml \
 		.global/deployment.yml \
 		.global/properties.yml \
@@ -1131,7 +1132,20 @@ build_normal_manifest() {
 		properties.yml \
 		credentials.yml \
 		cloudfoundry.yml \
-		name.yml)
+		name.yml
+}
+
+build_normal_manifest() {
+	must_be_in_an_environment
+	need_command spruce
+
+	normal_site_metadata > ${DEPLOYMENT_ENV_DIR}/.begin.yml
+	(cd ${DEPLOYMENT_ENV_DIR}
+	 spruce $SPRUCE_OPTS merge --prune meta \
+        .begin.yml \
+        $(ensure_normal_files)
+     )
+
 	rc=$?
 
 	rm -f ${DEPLOYMENT_ENV_DIR}/.begin.yml

--- a/bin/genesis
+++ b/bin/genesis
@@ -287,16 +287,18 @@ Global Definitions
 
 This directory contains templates that describe the common elements of this
 deployments, to be shared (and possibly overridden) by sites and environments.
+The templates are merged in the following order:
+
+  global/jobs.yml             Specify what jobs will make up the canonical
+                              deployment, and what templates to apply to them.
 
   global/deployment.yml       Define the global structure of all deployments
                               with the correct param calls to remind template
                               writers to override the correct things.
 
-  global/jobs.yml             Specify what jobs will make up the canonical
-                              deployment, and what templates to apply to them.
-
   global/properties.yml       Define the properties (global or per-job) for this
                               deployment.
+
 
 NOTE: If you make changes to the templates in here, they will automatically
 propagate to any newly-created environments, but you will need to run a
@@ -314,6 +316,7 @@ deployments, to be shared (and possibly overridden) by sites and environments.
                               deployments, with the correct param calls to remind
                               template writers to override the correct things.
 
+
 NOTE: If you make changes to the templates in here, they will automatically
 propagate to any newly-created environments, but you will need to run a
 refresh for existing environments to receive those updates.
@@ -325,16 +328,18 @@ Global Definitions
 
 This directory contains templates that describe the common elements of BOSH
 deployments, to be shared (and possibly overridden) by sites and environments.
+The templates are merged in the following order:
+
+  global/jobs.yml             Specify what jobs will make up the BOSH deployment,
+                              and what templates to apply to them.
 
   global/deployment.yml       Define the global structure of all BOSH deployments
                               with the correct param calls to remind template
                               writers to override the correct things.
 
-  global/jobs.yml             Specify what jobs will make up the BOSH deployment,
-                              and what templates to apply to them.
-
   global/properties.yml       Define the properties (global or per-job) for the
                               BOSH deployment.
+
 
 NOTE: If you make changes to the templates in here, they will automatically
 propagate to any newly-created environments, but you will need to run a
@@ -353,28 +358,33 @@ create_site_readme() {
 Site Definitions (${site})
 
 This directory contains templates that describe the infrastructure-specific
-settings and site-wide properties.
-
-  site/networks.yml           Define what networks to use for all the
-                              environments in this site (although you may
-                              want to defer the actual numbering to the
-                              environment level.
+settings and site-wide properties.  The templates are merged in the following order:
 
   site/disk-pools.yml         If you need to, you can put disk pool
                               definitions in this file.
 
-  site/resource-pools.yml     Set up the resource pools to use for job
-                              virtual machines, and apply their cloud
-                              properties (i.e. availability zones)
+  site/update.yml             Specify job update parameters here, which can
+                              change based on the cloud provider in use,
+                              and its performance characteristics.
 
   site/jobs.yml               Here you can modify the list of jobs defined
                               at the global level, remove jobs (by setting
                               their instances: count to 0), and supply any
                               additional, site-wide job properties.
 
-  site/update.yml             Specify job update parameters here, which can
-                              change based on the cloud provider in use,
-                              and its performance characteristics.
+  site/networks.yml           Define what networks to use for all the
+                              environments in this site (although you may
+                              want to defer the actual numbering to the
+                              environment level.
+
+  site/resource-pools.yml     Set up the resource pools to use for job
+                              virtual machines, and apply their cloud
+                              properties (i.e. availability zones)
+
+  site/properties.yml         Define properties (both globally and per-job),
+                              that are specific to this environment.  These will
+                              most likely override global properties.
+
 
 NOTE: If you make changes to the templates in here, they will automatically
 propagate to any newly-created environments, but you will need to run a
@@ -386,7 +396,7 @@ EOF
 Site Definitions (${site})
 
 This directory contains templates that describe the infrastructure-specific
-settings and site-wide properties.
+settings and site-wide properties.  The templates are merged in the following order:
 
   site/infra.yml              Define infrastructure-specific settings for
                               this MicroBOSH deployment, including resources,
@@ -406,24 +416,29 @@ EOF
 Site Definitions (${site})
 
 This directory contains templates that describe the infrastructure-specific
-settings and site-wide properties.
+settings and site-wide properties.  The templates are merged in the following order:
+
+  site/disk-pools.yml         If you need to, you can put disk pool
+                              definitions in this file.
+
+  site/jobs.yml               Here you can modify the list of jobs defined
+                              at the global level, remove jobs (by setting
+                              their instances: count to 0), and supply any
+                              additional, site-wide job properties.
 
   site/networks.yml           Define what networks to use for all the
                               environments in this site (although you may
                               want to defer the actual numbering to the
                               environment level.
 
-  site/disk-pools.yml         If you need to, you can put disk pool
-                              definitions in this file.
-
   site/resource-pools.yml     Set up the resource pools to use for job
                               virtual machines, and apply their cloud
                               properties (i.e. availability zones)
 
-  site/jobs.yml               Here you can modify the list of jobs defined
-                              at the global level, remove jobs (by setting
-                              their instances: count to 0), and supply any
-                              additional, site-wide job properties.
+  site/properties.yml         Define properties (both globally and per-job),
+                              that are specific to this environment.  These will
+                              most likely override global properties.
+
 
 NOTE: If you make changes to the templates in here, they will automatically
 propagate to any newly-created environments, but you will need to run a
@@ -446,34 +461,34 @@ Environment Definitions (${site}/${name})
 This directory contains templates that describe the environment-specific
 settings of a single deployment.  These templates will be combined with
 the global and site templates to produce a single BOSH manifest for deployment
-purposes.
+purposes.  The templates are merged in the following order:
+
+  monitoring.yml              Configure whatever (external) monitoring system you
+                              want to track the performance and health of your
+                              deployment.
+
+  networking.yml              Configure the network numbering for this deployment.
+
+  director.yml                Identify the BOSH director UUID for this deployment.
+
+  scaling.yml                 Define the scaling properties for this deployment,
+                              including things like the number of instances, sizes
+                              of persistent disks, resource pool limits, etc.
+
+  properties.yml              Define properties (both globally and per-job),
+                              that are specific to this environment.  These will
+                              most likely override global and site properties.
+
+  credentials.yml             Define passwords and credentials here, so that they
+                              are centralized.  Keep in mind that commiting these
+                              into version control incurs some security risk.
 
   cloudfoundry.yml            For deployments that integrate with Cloud Foundry
                               installations (i.e. as service brokers), you can
                               specify the integration details here, including
                               things like the CF API, credentials, domains, etc.
 
-  credentials.yml             Define passwords and credentials here, so that they
-                              are centralized.  Keep in mind that commiting these
-                              into version control incurs some security risk.
-
-  director.yml                Identify the BOSH director UUID for this deployment.
-
-  monitoring.yml              Configure whatever (external) monitoring system you
-                              want to track the performance and health of your
-                              deployment.
-
   name.yml                    Specify the name of this deployment.
-
-  properties.yml              Define properties (both globally and per-job),
-                              that are specific to this environment.  These will
-                              most likely override global properties.
-
-  networking.yml              Configure the network numbering for this deployment.
-
-  scaling.yml                 Define the scaling properties for this deployment,
-                              including things like the number of instances, sizes
-                              of persistent disks, resource pool limits, etc.
 
 
 This directory also contains a Makefile that makes it easier to build
@@ -488,17 +503,17 @@ Environment Definitions (${site}/${name})
 This directory contains templates that describe the environment-specific
 settings of a single MicroBOSH deployment.  These templates will be combined
 with the global and site templates to produce a single manifest suitable for
-deployment via \`bosh micro'
-
-  director.yml                Identify the BOSH director UUID for this deployment.
-
-  name.yml                    Specify the name of this MicroBOSH deployment.
+deployment via \`bosh micro'.  The templates are merged in the following order:
 
   infra.yml                   Configure the Infrastructure that this MicroBOSH will
                               be deployed on top of.
 
   scaling.yml                 Define the scaling properties for this deployment,
                               including things like disk sizing, RAM, etc.
+
+  director.yml                Identify the BOSH director UUID for this deployment.
+
+  name.yml                    Specify the name of this MicroBOSH deployment.
 
 
 This directory also contains a Makefile that makes it easier to build
@@ -513,23 +528,19 @@ Environment Definitions (${site}/${name})
 This directory contains templates that describe the environment-specific
 settings of a single bosh-init deployment.  These templates will be combined
 with the global and site templates to produce a single manifest suitable for
-deployment via \`bosh-init'
+deployment via \`bosh-init'.  The templates are merged in the following order:
+
+  networking.yml              Configure the network numbering for this BOSH.
+
+  properties.yml              Define properties (both globally and per-job),
+                              that are specific to this environment.  These will
+                              most likely override global and site properties.
 
   credentials.yml             Define passwords and credentials here, so that they
                               are centralized.  Keep in mind that commiting these
                               into version control incurs some security risk.
 
   name.yml                    Specify the name of this deployment.
-
-  properties.yml              Define properties (both globally and per-job),
-                              that are specific to this environment.  These will
-                              most likely override global properties.
-
-  networking.yml              Configure the network numbering for this BOSH.
-
-  scaling.yml                 Define the scaling properties for this deployment,
-                              including things like the number of instances, sizes
-                              of persistent disks, resource pool limits, etc.
 
 
 This directory also contains a Makefile that makes it easier to build
@@ -1104,9 +1115,23 @@ build_normal_manifest() {
 	(cd ${DEPLOYMENT_ENV_DIR}
 	 spruce $SPRUCE_OPTS merge --prune meta \
 		.begin.yml \
-		.global/*.yml \
-		.site/*.yml \
-        *.yml )
+		.global/jobs.yml \
+		.global/deployment.yml \
+		.global/properties.yml \
+		.site/disk-pools.yml \
+		.site/update.yml \
+		.site/jobs.yml \
+		.site/networks.yml \
+		.site/resource-pools.yml \
+        .site/properties.yml \
+		monitoring.yml \
+		networking.yml \
+		director.yml \
+		scaling.yml \
+		properties.yml \
+		credentials.yml \
+		cloudfoundry.yml \
+		name.yml)
 	rc=$?
 
 	rm -f ${DEPLOYMENT_ENV_DIR}/.begin.yml
@@ -1197,6 +1222,7 @@ build_bosh_init_manifest() {
 		.site/jobs.yml \
 		.site/networks.yml \
 		.site/resource-pools.yml \
+        .site/properties.yml \
 		networking.yml \
 		properties.yml \
 		credentials.yml \

--- a/bin/genesis
+++ b/bin/genesis
@@ -101,8 +101,7 @@ setup() {
 
 ensure_yaml_files() {
   for i in $*; do
-    [ ! -f $i ] && echo "--- {}" > $i
-    echo $i
+    [ -f $i ] && echo $i
     shift
   done
 }

--- a/bin/genesis
+++ b/bin/genesis
@@ -1123,7 +1123,7 @@ build_normal_manifest() {
 		.site/jobs.yml \
 		.site/networks.yml \
 		.site/resource-pools.yml \
-        .site/properties.yml \
+		.site/properties.yml \
 		monitoring.yml \
 		networking.yml \
 		director.yml \
@@ -1222,7 +1222,7 @@ build_bosh_init_manifest() {
 		.site/jobs.yml \
 		.site/networks.yml \
 		.site/resource-pools.yml \
-        .site/properties.yml \
+		.site/properties.yml \
 		networking.yml \
 		properties.yml \
 		credentials.yml \

--- a/bin/genesis
+++ b/bin/genesis
@@ -1104,22 +1104,9 @@ build_normal_manifest() {
 	(cd ${DEPLOYMENT_ENV_DIR}
 	 spruce $SPRUCE_OPTS merge --prune meta \
 		.begin.yml \
-		.global/jobs.yml \
-		.global/deployment.yml \
-		.global/properties.yml \
-		.site/disk-pools.yml \
-		.site/update.yml \
-		.site/jobs.yml \
-		.site/networks.yml \
-		.site/resource-pools.yml \
-		monitoring.yml \
-		networking.yml \
-		director.yml \
-		scaling.yml \
-		properties.yml \
-		credentials.yml \
-		cloudfoundry.yml \
-		name.yml)
+		.global/*.yml \
+		.site/*.yml \
+        *.yml )
 	rc=$?
 
 	rm -f ${DEPLOYMENT_ENV_DIR}/.begin.yml


### PR DESCRIPTION
This will fix the problem for now so we can start using Genesis in our particular projects - but I do realize a flaw in this solution:  The files missing in .site and .global will be filled in with the missing stubs, but it won't do anything about adding stubs to ../site and ../../global for permanent inclusion.  I'm not sure how to best implement without maintaining multiple file lists within the code, making it harder to keep track of where to make alterations when needed.  Perhaps we can chat about it tomorrow.

For now, issuing the pull request.  We can tweak as we figure things out.