### PR TITLE
Support migrating to genesis from existing bosh-init

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1972,6 +1972,20 @@ cmd_deploy() {
 		[[ -n $DEBUG_LEAVE_THE_CREDS_THERE ]] || \
 			trap "rm -f ${DEPLOYMENT_ENV_DIR}/manifests/.deploy.yml" QUIT TERM INT EXIT
 
+		if [[ ! -f "${DEPLOYMENT_ENV_DIR}/manifests/.deploy-state.json" ]]; then
+			echo "No existing genesis-created bosh-init statefile detected. Please help genesis find it."
+			echo -n "Path to existing bosh-init statefile (leave blank for new deployments): "
+			read statefile
+			while [[ -n "${statefile}" && ! -f "${statefile}" ]]; do
+				echo "Invalid path."
+				echo -n "Path to existing bosh-init statefile (leave blank for new deployments): "
+				read statefile
+			done
+			if [[ -n "${statefile}" ]]; then
+				mv "${statefile}" ${DEPLOYMENT_ENV_DIR}/manifests/.deploy-state.yml
+			fi
+		fi
+
 		bosh-init deploy ${DEPLOYMENT_ENV_DIR}/manifests/.deploy.yml
 		exit $?
 		;;


### PR DESCRIPTION
genesis deploy now detects 'new' genesis deployments for bosh-init,
and prompts users to specify the existing manifest-state.json file
in the event of the deployment being a migration from a non-genesis
bosh-init deploy.