### PR TITLE
Automagic generation of director.yml and name.yml

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -913,11 +913,25 @@ create_normal_environment() {
 	create_makefile ${root}/Makefile
 	create_environment_readme ${site} ${name} >${root}/README
 
-	for file in cloudfoundry credentials director monitoring name properties networking scaling; do
+	for file in cloudfoundry credentials director monitoring properties networking scaling; do
 		cat > ${root}/${file}.yml <<EOF
 --- {}
 EOF
 	done
+
+	local director_uuid
+	director_uuid=$(bosh status --uuid)
+	if [[ "$?" -eq 0 ]] ; then
+		cat <<EOF > ${root}/director.yml
+---
+director_uuid: ${director_uuid}
+EOF
+	fi
+
+	cat <<EOF > ${root}/name.yml
+----
+name: ${site}-${name}-${DEPLOYMENT_NAME}
+EOF
 
 	refresh_global ${site} ${name}
 	refresh_site   ${site} ${name}


### PR DESCRIPTION
```
$ genesis new environment mysite testenv2
Created environment mysite/testenv2:
.../concourse-deployments/mysite/testenv2
├── cloudfoundry.yml
├── credentials.yml
├── director.yml
├── Makefile
├── monitoring.yml
├── name.yml
├── networking.yml
├── properties.yml
├── README
└── scaling.yml

0 directories, 10 files
$ cat mysite/testenv2/director.yml
---
director_uuid: c0f1b55c-90a7-4507-bc39-73476e21d7b0
$ cat mysite/testenv2/name.yml
----
name: mysite-testenv2-concourse
```

Closes #17 