### PR TITLE
Support vault prefixes for auto-generating creds

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -928,10 +928,24 @@ director_uuid: ${director_uuid}
 EOF
 	fi
 
+	export VAULT_PREFIX=secret/${site}/$name/${DEPLOYMENT_NAME}
 	cat <<EOF > ${root}/name.yml
 ----
 name: ${site}-${name}-${DEPLOYMENT_NAME}
+meta:
+  vault_prefix: ${VAULT_PREFIX}
 EOF
+
+	if [[ -d ${DEPLOYMENT_ROOT}/.env_hooks ]]; then
+		pushd ${DEPLOYMENT_ROOT}/.env_hooks
+		for file in *; do
+			if [[ -f ${file} && -x ${file} ]]; then
+				echo "Running env setup hook: ${file}"
+				./${file}
+			fi
+		done
+		popd
+	fi
 
 	refresh_global ${site} ${name}
 	refresh_site   ${site} ${name}
@@ -996,6 +1010,25 @@ create_bosh_init_environment() {
 --- {}
 EOF
 	done
+
+	export VAULT_PREFIX=secret/${site}/$name/${DEPLOYMENT_NAME}
+	cat <<EOF > ${root}/name.yml
+----
+name: ${site}-${name}-${DEPLOYMENT_NAME}
+meta:
+  vault_prefix: ${VAULT_PREFIX}
+EOF
+
+	if [[ -d ${DEPLOYMENT_ROOT}/.env_hooks ]]; then
+		pushd ${DEPLOYMENT_ROOT}/.env_hooks
+		for file in *; do
+			if [[ -f ${file} && -x ${file} ]]; then
+				echo "Running env setup hook: ${file}"
+				./${file}
+			fi
+		done
+		popd
+	fi
 
 	refresh_global ${site} ${name}
 	refresh_site   ${site} ${name}

--- a/bin/genesis
+++ b/bin/genesis
@@ -79,17 +79,6 @@ line() {
 	echo
 }
 
-auto_sed() {
-	cmd=$1
-	shift
-
-	if [[ "$(uname -s)" == "Darwin" ]]; then
-		sed -E -e "$cmd"
-	else
-		sed -r -e "$cmd"
-	fi
-}
-
 version_checker() {
 	if [[ $1 == $2 ]]
 	then
@@ -136,21 +125,21 @@ setup() {
 	if [[ -f ${DEPLOYMENT_ROOT}/.genesis_deps ]]; then
 		errors=""
 		while IFS='' read -r line || [[ -n "$line" ]]; do
-			cmd=$(echo $line | cut -d ":" -f1)
-			version=$(echo $line | cut -d ":" -f2- | auto_sed 's/^ +//' | auto_sed 's/ +$//')
+			cmd=$(echo $line | perl -pe 's|^(.*?):.*$|$1|')
+			ver=$(echo $line | perl -pe 's|^.*?: *(.*)$|$1|')
 			if [[ ! -x $(which ${cmd}) ]]; then
 				errors="This genesis deployment requires the '${cmd}' command\n${errors}"
 				continue
 			fi
-			if [[ ${version} != "null" && ${version} != '~' ]]; then
+			if [[ ${ver} != "null" && ${ver} != '~' ]]; then
 				current_version=$(${cmd} -v 2>&1 | perl -pe 's|.*?(\d+\.\d+(\.\d+)*).*|$1|')
 				if [[ -z ${current_version} || $(echo ${current_version} | egrep '[^0-9\.]') ]]; then
-					errors="This genesis deployment requires ${cmd} version ${version}, but the current version could not be parsed\n${errors}"
+					errors="This genesis deployment requires ${cmd} version ${ver}, but the current ver could not be parsed\n${errors}"
 					echo ${current_version}
 					continue
 				fi
-				if ! version_checker ${current_version} ${version}; then
-					errors="This genesis deployment requires ${cmd} version ${version} (found ${current_version})\n${errors}"
+				if ! version_checker ${current_version} ${ver}; then
+					errors="This genesis deployment requires ${cmd} version ${ver} (found ${current_version})\n${errors}"
 					continue
 				fi
 			fi
@@ -999,23 +988,22 @@ director_uuid: ${director_uuid}
 EOF
 	fi
 
-	export VAULT_PREFIX=secret/${site}/$name/${DEPLOYMENT_NAME}
+	VAULT_PREFIX=secret/${site}/$name/${DEPLOYMENT_NAME}
 	cat <<EOF > ${root}/name.yml
-----
+---
 name: ${site}-${name}-${DEPLOYMENT_NAME}
 meta:
   vault_prefix: ${VAULT_PREFIX}
 EOF
 
 	if [[ -d ${DEPLOYMENT_ROOT}/.env_hooks ]]; then
-		pushd ${DEPLOYMENT_ROOT}/.env_hooks
-		for file in *; do
+		for file in ${DEPLOYMENT_ROOT}/.env_hooks/*; do
 			if [[ -f ${file} && -x ${file} ]]; then
 				echo "Running env setup hook: ${file}"
-				./${file}
+				export VAULT_PREFIX DEPLOYMENT_NAME DEPLOYMENT_SITE
+				${file}
 			fi
 		done
-		popd
 	fi
 
 	refresh_global ${site} ${name}
@@ -1082,23 +1070,22 @@ create_bosh_init_environment() {
 EOF
 	done
 
-	export VAULT_PREFIX=secret/${site}/$name/${DEPLOYMENT_NAME}
+	VAULT_PREFIX=secret/${site}/$name/${DEPLOYMENT_NAME}
 	cat <<EOF > ${root}/name.yml
-----
+---
 name: ${site}-${name}-${DEPLOYMENT_NAME}
 meta:
   vault_prefix: ${VAULT_PREFIX}
 EOF
 
 	if [[ -d ${DEPLOYMENT_ROOT}/.env_hooks ]]; then
-		pushd ${DEPLOYMENT_ROOT}/.env_hooks
-		for file in *; do
+		for file in ${DEPLOYMENT_ROOT}/.env_hooks/*; do
 			if [[ -f ${file} && -x ${file} ]]; then
 				echo "Running env setup hook: ${file}"
-				./${file}
+				export VAULT_PREFIX DEPLOYMENT_NAME DEPLOYMENT_SITE
+				${file}
 			fi
 		done
-		popd
 	fi
 
 	refresh_global ${site} ${name}

--- a/bin/genesis
+++ b/bin/genesis
@@ -1075,6 +1075,10 @@ EOF
 	done
 
 	VAULT_PREFIX=secret/${site}/$name/${DEPLOYMENT_NAME}
+	DEPLOYMENT_SITE=${site}
+	DEPLOYMENT_ENVIRONMENT=${name}
+	ENVIRONMENT_ROOT=${DEPLOYMENT_ROOT}/${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}
+
 	cat <<EOF > ${root}/name.yml
 ---
 name: ${site}-${name}-${DEPLOYMENT_NAME}

--- a/bin/genesis
+++ b/bin/genesis
@@ -1,5 +1,5 @@
 #!/bin/bash
-VERSION=1.4.0
+VERSION=1.5.0
 
 USERNAME=$(whoami)
 CANON_REPO=https://github.com/starkandwayne/genesis
@@ -79,6 +79,49 @@ line() {
 	echo
 }
 
+auto_sed() {
+	cmd=$1
+	shift
+
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		sed -E -e "$cmd"
+	else
+		sed -r -e "$cmd"
+	fi
+}
+
+version_checker() {
+	if [[ $1 == $2 ]]
+	then
+		return 0
+	fi
+	local IFS=.
+	local i actual=($1) expected=($2)
+	# fill empty fields in actual with zeros
+	for ((i=${#actual[@]}; i<${#expected[@]}; i++))
+	do
+		actual[i]=0
+	done
+	actual_numeric=0
+	expected_numeric=0
+	for ((i=0; i<${#actual[@]}; i++))
+	do
+		if [[ -z ${expected[i]} ]]
+		then
+			# fill empty fields in expected with zeros
+			expected[i]=0
+		fi
+		actual_numeric=$((actual_numeric+${actual[i]}*1000**(${#actual[@]}-i)))
+		expected_numeric=$((expected_numeric+${expected[i]}*1000**(${#expected[@]}-i)))
+	done
+
+
+	if [[ ${actual_numeric} < ${expected_numeric} ]]; then
+		return 1
+	fi
+	return 0
+}
+
 setup() {
 	if [[ ${DEPLOYMENT_ROOT:-unset} != "unset" ]]; then
 		return
@@ -88,6 +131,34 @@ setup() {
 	if [[ -z ${DEPLOYMENT_ROOT:-} ]]; then
 		echo >&2 "Unable to determine Genesis DEPLOYMENT_ROOT"
 		exit 3
+	fi
+
+	if [[ -f ${DEPLOYMENT_ROOT}/.genesis_deps ]]; then
+		errors=""
+		while IFS='' read -r line || [[ -n "$line" ]]; do
+			cmd=$(echo $line | cut -d ":" -f1)
+			version=$(echo $line | cut -d ":" -f2- | auto_sed 's/^ +//' | auto_sed 's/ +$//')
+			if [[ ! -x $(which ${cmd}) ]]; then
+				errors="This genesis deployment requires the '${cmd}' command\n${errors}"
+				continue
+			fi
+			if [[ ${version} != "null" && ${version} != '~' ]]; then
+				current_version=$(${cmd} -v 2>&1 | perl -pe 's|.*?(\d+\.\d+(\.\d+)*).*|$1|')
+				if [[ -z ${current_version} || $(echo ${current_version} | egrep '[^0-9\.]') ]]; then
+					errors="This genesis deployment requires ${cmd} version ${version}, but the current version could not be parsed\n${errors}"
+					echo ${current_version}
+					continue
+				fi
+				if ! version_checker ${current_version} ${version}; then
+					errors="This genesis deployment requires ${cmd} version ${version} (found ${current_version})\n${errors}"
+					continue
+				fi
+			fi
+		done < ${DEPLOYMENT_ROOT}/.genesis_deps
+		if [[ -n ${errors} ]]; then
+			echo -e ${errors}
+			exit 1
+		fi
 	fi
 
 	# What type of deployment is this?

--- a/bin/genesis
+++ b/bin/genesis
@@ -134,7 +134,7 @@ setup() {
 			if [[ ${ver} != "null" && ${ver} != '~' ]]; then
 				current_version=$(${cmd} -v 2>&1 | perl -pe 's|.*?(\d+\.\d+(\.\d+)*).*|$1|')
 				if [[ -z ${current_version} || $(echo ${current_version} | egrep '[^0-9\.]') ]]; then
-					errors="This genesis deployment requires ${cmd} version ${ver}, but the current ver could not be parsed\n${errors}"
+					errors="This genesis deployment requires ${cmd} version ${ver}, but the current version could not be parsed\n${errors}"
 					echo ${current_version}
 					continue
 				fi
@@ -989,6 +989,10 @@ EOF
 	fi
 
 	VAULT_PREFIX=secret/${site}/$name/${DEPLOYMENT_NAME}
+	DEPLOYMENT_SITE=${site}
+	DEPLOYMENT_ENVIRONMENT=${name}
+	ENVIRONMENT_ROOT=${DEPLOYMENT_ROOT}/${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}
+
 	cat <<EOF > ${root}/name.yml
 ---
 name: ${site}-${name}-${DEPLOYMENT_NAME}
@@ -1000,7 +1004,7 @@ EOF
 		for file in ${DEPLOYMENT_ROOT}/.env_hooks/*; do
 			if [[ -f ${file} && -x ${file} ]]; then
 				echo "Running env setup hook: ${file}"
-				export VAULT_PREFIX DEPLOYMENT_NAME DEPLOYMENT_SITE
+				export VAULT_PREFIX DEPLOYMENT_NAME DEPLOYMENT_SITE DEPLOYMENT_ENVIRONMENT DEPLOYMENT_ROOT ENVIRONMENT_ROOT
 				${file}
 			fi
 		done
@@ -1082,7 +1086,7 @@ EOF
 		for file in ${DEPLOYMENT_ROOT}/.env_hooks/*; do
 			if [[ -f ${file} && -x ${file} ]]; then
 				echo "Running env setup hook: ${file}"
-				export VAULT_PREFIX DEPLOYMENT_NAME DEPLOYMENT_SITE
+				export VAULT_PREFIX DEPLOYMENT_NAME DEPLOYMENT_SITE DEPLOYMENT_ENVIRONMENT DEPLOYMENT_ROOT ENVIRONMENT_ROOT=${DEPLOYMENT_ROOT}/${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}
 				${file}
 			fi
 		done


### PR DESCRIPTION
- Added a default 'meta.vault_prefix' property, so allow
  deployments to reference it when resolving vault keys
- Added support for running scripts as env-setup-hooks,
  so that deployments can have their credentials, or any initial
  setup performed after creating the environment.