### PR TITLE
Utilize the Genesis Index for Stemcell / Releases

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -16,7 +16,7 @@ fi
 WORKDIR=""
 need_a_workdir() {
 	if [[ -z ${WORKDIR} ]]; then
-    WORKDIR=$(mktemp -d -t genesis.XXXXXX)
+		WORKDIR=$(mktemp -d -t genesis.XXXXXX)
 		trap "rm -rf ${WORKDIR}" INT TERM QUIT EXIT
 	fi
 }
@@ -995,17 +995,6 @@ normal_site_metadata() {
 	if [[ -f "${DEPLOYMENT_ENV_DIR}/.site/stemcell/sha1" ]]; then
 		stemcell_sha1=$(cat "${DEPLOYMENT_ENV_DIR}/.site/stemcell/sha1")
 	fi
-	if [[ -z ${stemcell_url} ]]; then
-		if [[ -n ${GENESIS_INDEX} ]]; then
-			echo >&2 "Checking ${GENESIS_INDEX} for correct URL/SHA1 of stemcell ${stemcell_name}/${stemcell_version}"
-			stemcell_url=$(    check_index url     stemcell "${stemcell_name}" ${stemcell_version})
-			stemcell_sha1=$(   check_index sha1    stemcell "${stemcell_name}" ${stemcell_version})
-			stemcell_version=$(check_index version stemcell "${stemcell_name}" ${stemcell_version})
-		fi
-	elif [[ -z ${stemcell_sha1} ]]; then
-		echo >&2 "Error: no SHA1 listed for stemcell ${stemcell_name}/${stemcell_version}"
-		exit 2
-	fi
 
 	if [[ ! -f "${DEPLOYMENT_ENV_DIR}/.site/releases" ]]; then
 		echo >&2 "Error: no releases listed for site"
@@ -1048,14 +1037,6 @@ EOF
 		local release_sha1=""
 		if [[ -f ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/sha1 ]]; then
 			release_sha1=$(cat ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/sha1)
-		fi
-		if [[ -z ${release_url} ]]; then
-			if [[ -n ${GENESIS_INDEX} ]]; then
-				echo >&2 "Checking ${GENESIS_INDEX} for correct URL/SHA1 of release ${rel}/${release_version}"
-				release_url=$(    check_index url     release "${rel}" ${release_version})
-				release_sha1=$(   check_index sha1    release "${rel}" ${release_version})
-				release_version=$(check_index version release "${rel}" ${release_version})
-			fi
 		fi
 
 		echo "  - name: ${rel}"
@@ -1603,15 +1584,40 @@ EOF
 }
 
 check_index() {
-	local want=${1:?check_index() - no desired attribute provided}
-	local type=${2:?check_index() - no type provided}
-	local name=${3:?check_index() - no name provided}
-	local vers=${4:-}
+	local type=${1:?check_index() - no type given}
+	local name=${2:?check_index() - no name given}
+	local version=${3:?check_index() - no version given}
 
-	if [[ -n ${vers} && ${vers} != "latest" ]]; then
-		curl -Lsk ${GENESIS_INDEX}/v1/${type}/${name}/v/${vers} | jq -r .${want} 2>/dev/null
-	else
-		curl -Lsk ${GENESIS_INDEX}/v1/${type}/${name}/latest    | jq -r .${want} 2>/dev/null
+	local root=""
+	case ${type} in
+	(stemcell)
+		root=${DEPLOYMENT_SITE_DIR}/site/stemcell
+		;;
+	(release)
+		root=${DEPLOYMENT_ROOT}/global/releases/${name}
+		;;
+	(*)
+		echo >&2 "Invalid type '${type}' given to check_index.  Please file a bug"
+		exit 2
+		;;
+	esac
+
+
+	if [[ -n ${GENESIS_INDEX} ]]; then
+		need_a_workdir
+		echo "  checking ${GENESIS_INDEX} for details on ${type} ${name}/${version}"
+		if [[ ${version} == "latest" ]]; then
+			curl -Lsk ${GENESIS_INDEX}/v1/${type}/${name}/latest       > ${WORKDIR}/index
+		else
+			curl -Lsk ${GENESIS_INDEX}/v1/${type}/${name}/v/${version} > ${WORKDIR}/index
+		fi
+
+		for thing in url sha1 version; do
+			v=$(jq -r .${thing} <${WORKDIR}/index)
+			if [[ -n ${v} ]]; then
+				echo "${v}" > ${root}/${thing}
+			fi
+		done
 	fi
 }
 
@@ -1628,23 +1634,10 @@ cmd_add_release() {
 	mkdir -p ${DEPLOYMENT_ROOT}/global/releases/${release}
 	echo ${version} > ${DEPLOYMENT_ROOT}/global/releases/${release}/version
 
-	if [[ -z ${url} && -n ${GENESIS_INDEX} ]]; then
-		echo "  checking ${GENESIS_INDEX} for details on release ${release}/${version}"
-		url=$(check_index url release "${release}" ${version})
-		if [[ -n ${url} ]]; then
-			sha1=$(check_index sha1 release "${release}" ${version})
-			if [[ -n ${sha1} ]]; then
-				echo ${sha1} > ${DEPLOYMENT_ROOT}/global/releases/${release}/sha1
-			fi
-
-			if [[ ${version} == "latest" ]]; then
-				version=$(check_index version release "${release}" ${version})
-				echo ${version} > ${DEPLOYMENT_ROOT}/global/releases/${release}/version
-			fi
-		fi
-	fi
 	if [[ -n ${url} ]]; then
 		echo ${url} > ${DEPLOYMENT_ROOT}/global/releases/${release}/url
+	else
+		check_index release ${release} ${version}
 	fi
 
 	if [[ ${version} == "latest" ]]; then
@@ -1738,22 +1731,7 @@ cmd_use_stemcell() {
 	echo "${name}"    > ${DEPLOYMENT_SITE_DIR}/site/stemcell/name
 	echo "${version}" > ${DEPLOYMENT_SITE_DIR}/site/stemcell/version
 
-	if [[ -n ${GENESIS_INDEX} ]]; then
-		echo "  checking ${GENESIS_INDEX} for details on stemcell ${name}/${version}"
-		url=$(check_index url stemcell "${name}" ${version})
-		if [[ -n ${url} ]]; then
-			echo "${url}" > ${DEPLOYMENT_SITE_DIR}/site/stemcell/url
-			sha1=$(check_index sha1 stemcell "${name}" ${version})
-			if [[ -n ${sha1} ]]; then
-				echo ${sha1} > ${DEPLOYMENT_SITE_DIR}/site/stemcell/sha1
-			fi
-
-			if [[ ${version} == "latest" ]]; then
-				version=$(check_index version stemcell "${name}" ${version})
-				echo ${version} > ${DEPLOYMENT_SITE_DIR}/site/stemcell/version
-			fi
-		fi
-	fi
+	check_index stemcell ${name} ${version}
 
 	if [[ ${version} == "latest" ]]; then
 		echo "Site ${DEPLOYMENT_SITE} is now using the latest version of stemcell ${name}"

--- a/bin/genesis
+++ b/bin/genesis
@@ -1003,7 +1003,8 @@ normal_site_metadata() {
 			stemcell_version=$(check_index version stemcell "${stemcell_name}" ${stemcell_version})
 		fi
 	elif [[ -z ${stemcell_sha1} ]]; then
-		stemcell_sha1=$(curl -Lsk ${stemcell_url} | checksum | awk '{print $1}')
+		echo >&2 "Error: no SHA1 listed for stemcell ${stemcell_name}/${stemcell_version}"
+		exit 2
 	fi
 
 	if [[ ! -f "${DEPLOYMENT_ENV_DIR}/.site/releases" ]]; then

--- a/bin/genesis
+++ b/bin/genesis
@@ -1627,16 +1627,32 @@ cmd_add_release() {
 	fi
 	mkdir -p ${DEPLOYMENT_ROOT}/global/releases/${release}
 	echo ${version} > ${DEPLOYMENT_ROOT}/global/releases/${release}/version
+
+	if [[ -z ${url} && -n ${GENESIS_INDEX} ]]; then
+		echo "  checking ${GENESIS_INDEX} for details on release ${release}/${version}"
+		url=$(check_index url release "${release}" ${version})
+		if [[ -n ${url} ]]; then
+			sha1=$(check_index sha1 release "${release}" ${version})
+			if [[ -n ${sha1} ]]; then
+				echo ${sha1} > ${DEPLOYMENT_ROOT}/global/releases/${release}/sha1
+			fi
+
+			if [[ ${version} == "latest" ]]; then
+				version=$(check_index version release "${release}" ${version})
+				echo ${version} > ${DEPLOYMENT_ROOT}/global/releases/${release}/version
+			fi
+		fi
+	fi
+	if [[ -n ${url} ]]; then
+		echo ${url} > ${DEPLOYMENT_ROOT}/global/releases/${release}/url
+	fi
+
 	if [[ ${version} == "latest" ]]; then
 		echo "Using the latest version of ${release}"
 	else
 		echo "Using v${version} of ${release}"
 	fi
 
-	if [[ -n ${url} ]]; then
-		echo ${url} > ${DEPLOYMENT_ROOT}/global/releases/${release}/url
-		echo "  (from ${url})"
-	fi
 	exit 0
 }
 
@@ -1721,6 +1737,23 @@ cmd_use_stemcell() {
 
 	echo "${name}"    > ${DEPLOYMENT_SITE_DIR}/site/stemcell/name
 	echo "${version}" > ${DEPLOYMENT_SITE_DIR}/site/stemcell/version
+
+	if [[ -n ${GENESIS_INDEX} ]]; then
+		echo "  checking ${GENESIS_INDEX} for details on stemcell ${name}/${version}"
+		url=$(check_index url stemcell "${name}" ${version})
+		if [[ -n ${url} ]]; then
+			echo "${url}" > ${DEPLOYMENT_SITE_DIR}/site/stemcell/url
+			sha1=$(check_index sha1 stemcell "${name}" ${version})
+			if [[ -n ${sha1} ]]; then
+				echo ${sha1} > ${DEPLOYMENT_SITE_DIR}/site/stemcell/sha1
+			fi
+
+			if [[ ${version} == "latest" ]]; then
+				version=$(check_index version stemcell "${name}" ${version})
+				echo ${version} > ${DEPLOYMENT_SITE_DIR}/site/stemcell/version
+			fi
+		fi
+	fi
 
 	if [[ ${version} == "latest" ]]; then
 		echo "Site ${DEPLOYMENT_SITE} is now using the latest version of stemcell ${name}"

--- a/bin/genesis
+++ b/bin/genesis
@@ -4,6 +4,12 @@ VERSION="(development build)"
 USERNAME=$(whoami)
 CANON_REPO=https://github.com/starkandwayne/genesis
 
+GENESIS_INDEX=${GENESIS_INDEX:-https://genesis.starkandwayne.com}
+GENESIS_INDEX=${GENESIS_INDEX%/}
+if [[ ${GENESIS_INDEX} = "no" ]]; then
+	GENESIS_INDEX=
+fi
+
 ####################################################
 # common functions used by other parts of Genesis
 
@@ -981,6 +987,25 @@ normal_site_metadata() {
 	fi
 	local stemcell_version=$(cat "${DEPLOYMENT_ENV_DIR}/.site/stemcell/version")
 
+	local stemcell_url=""
+	if [[ -f "${DEPLOYMENT_ENV_DIR}/.site/stemcell/url" ]]; then
+		stemcell_url=$(cat "${DEPLOYMENT_ENV_DIR}/.site/stemcell/url")
+	fi
+	local stemcell_sha1=""
+	if [[ -f "${DEPLOYMENT_ENV_DIR}/.site/stemcell/sha1" ]]; then
+		stemcell_sha1=$(cat "${DEPLOYMENT_ENV_DIR}/.site/stemcell/sha1")
+	fi
+	if [[ -z ${stemcell_url} ]]; then
+		if [[ -n ${GENESIS_INDEX} ]]; then
+			echo >&2 "Checking ${GENESIS_INDEX} for correct URL/SHA1 of stemcell ${stemcell_name}/${stemcell_version}"
+			stemcell_url=$(    check_index url     stemcell "${stemcell_name}" ${stemcell_version})
+			stemcell_sha1=$(   check_index sha1    stemcell "${stemcell_name}" ${stemcell_version})
+			stemcell_version=$(check_index version stemcell "${stemcell_name}" ${stemcell_version})
+		fi
+	elif [[ -z ${stemcell_sha1} ]]; then
+		stemcell_sha1=$(curl -Lsk ${stemcell_url} | checksum | awk '{print $1}')
+	fi
+
 	if [[ ! -f "${DEPLOYMENT_ENV_DIR}/.site/releases" ]]; then
 		echo >&2 "Error: no releases listed for site"
 		exit 2
@@ -1003,12 +1028,43 @@ normal_site_metadata() {
 meta:
   stemcell:
     name: ${stemcell_name}
-    version: "${stemcell_version}"
-releases:
+    version: ${stemcell_version}
 EOF
+	if [[ -n ${stemcell_url} ]]; then
+		echo "    url: ${stemcell_url}"
+	fi
+	if [[ -n ${stemcell_sha1} ]]; then
+		echo "    sha1: ${stemcell_sha1}"
+	fi
+	echo "releases:"
+
 	for rel in ${releases}; do
+		local release_version=$(cat ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/version)
+		local release_url=""
+		if [[ -f ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/url ]]; then
+			release_url=$(cat ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/url)
+		fi
+		local release_sha1=""
+		if [[ -f ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/sha1 ]]; then
+			release_sha1=$(cat ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/sha1)
+		fi
+		if [[ -z ${release_url} ]]; then
+			if [[ -n ${GENESIS_INDEX} ]]; then
+				echo >&2 "Checking ${GENESIS_INDEX} for correct URL/SHA1 of release ${rel}/${release_version}"
+				release_url=$(    check_index url     release "${rel}" ${release_version})
+				release_sha1=$(   check_index sha1    release "${rel}" ${release_version})
+				release_version=$(check_index version release "${rel}" ${release_version})
+			fi
+		fi
+
 		echo "  - name: ${rel}"
-		echo "    version: \"$(cat ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/version)\""
+		echo "    version: ${release_version}"
+		if [[ -n ${release_url} ]]; then
+			echo "    url: \"${release_url}\""
+		fi
+		if [[ -n ${release_sha1} ]]; then
+			echo "    sha1: \"${release_sha1}\""
+		fi
 	done
 }
 
@@ -1545,9 +1601,23 @@ EOF
 	exit 1
 }
 
+check_index() {
+	local want=${1:?check_index() - no desired attribute provided}
+	local type=${2:?check_index() - no type provided}
+	local name=${3:?check_index() - no name provided}
+	local vers=${4:-}
+
+	if [[ -n ${vers} && ${vers} != "latest" ]]; then
+		curl -Lsk ${GENESIS_INDEX}/v1/${type}/${name}/v/${vers} | jq -r .${want} 2>/dev/null
+	else
+		curl -Lsk ${GENESIS_INDEX}/v1/${type}/${name}/latest    | jq -r .${want} 2>/dev/null
+	fi
+}
+
 cmd_add_release() {
-	local release=${1:?USAGE: genesis add relese NAME VERSION}
+	local release=${1:?USAGE: genesis add relese NAME [VERSION] [URL]}
 	local version=${2:-latest}
+	local url=${3:-}
 
 	setup
 	if [[ -d ${DEPLOYMENT_ROOT}/global/releases/${release} ]]; then
@@ -1560,6 +1630,11 @@ cmd_add_release() {
 		echo "Using the latest version of ${release}"
 	else
 		echo "Using v${version} of ${release}"
+	fi
+
+	if [[ -n ${url} ]]; then
+		echo ${url} > ${DEPLOYMENT_ROOT}/global/releases/${release}/url
+		echo "  (from ${url})"
 	fi
 	exit 0
 }

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,25 @@
+# Improvements
+
+- Genesis now supports the Genesis Index, a free service available
+  online at https://genesis.starkandwayne.com that tracks releases
+  and stemcells from bosh.io and Github.  Genesis now uses this to
+  supply version, tarball URL and SHA1 checksum information for
+  both releases and stemcells.
+
+  This makes it possible for newer BOSH CLIs to transparently
+  upload missing releases and stemcells to your BOSH director,
+  which in turn enables Concourse pipelines to easily roll
+  stemcell and release upgrades through unattended.
+
+  One side-effect of this change is that the "latest" version
+  keyword now no longer means "latest available on the BOSH
+  director", but instead "latest known to the index".
+
+  The public Genesis Index is automated and watches Github and
+  bosh.io for new releases and stemcells, so that it stays
+  up-to-date.  Sites wishing to run a local Genesis Index may
+  easily do so by pushing the [genesis-index][index] app to their
+  Cloud Foundry instance.
+
+
+[index]: https://github.com/starkandwayne/genesis-index


### PR DESCRIPTION
URLs, SHA1 checksums and versions (for "latest") will now be looked up
from the Genesis Index (per the GENESIS_INDEX environment variable).  By
default, this is set to https://genesis.starkandwayne.com/, but can be
overridden (for on-premise instances of the index) or disabled
completely by setting it to the value "no".

If a deployment supplies url file for a stemcell or a release, the trip
to the index will be skipped.  Any releases or stemcells that are
missing will consult the index.

This change also means that "latest" now no longer means "latest
available on your BOSH director", but instead means "latest known to the
index"