### PR TITLE
Genesis image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM concourse/concourse-ci
+
+ENV SPRUCE_VERSION=1.5.0 \
+  CF_CLI_VERSION=6.13.0 \
+  VAULT_VERSION=0.6.0 \
+  GENESIS_VERSION=1.5.1
+
+# base packages
+RUN apt-get install -yy curl file
+
+# spruce
+RUN curl -L >/usr/bin/spruce https://github.com/geofffranks/spruce/releases/download/v${SPRUCE_VERSION}/spruce-linux-amd64 \
+      && chmod 0755 /usr/bin/spruce
+
+# jq
+RUN curl -L >/usr/bin/jq http://stedolan.github.io/jq/download/linux64/jq \
+      && chmod 755 /usr/bin/jq
+
+# vault
+RUN curl -L >/tmp/vault.zip https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip \
+     && unzip /tmp/vault.zip -d /usr/bin/
+
+RUN curl -L >/usr/bin/genesis https://github.com/starkandwayne/genesis/releases/download/v${GENESIS_VERSION}/genesis \
+      && chmod 755 /usr/bin/genesis \
+      && genesis -v
+

--- a/ci/scripts/shipit
+++ b/ci/scripts/shipit
@@ -53,6 +53,7 @@ pushd $REPO_ROOT
 
 mkdir artifacts
 cp bin/${BINARY} artifacts/${BINARY}
+auto_sed Dockerfile "s/GENESIS_VERSION=.*/GENESIS_VERSION=${VERSION}/"
 auto_sed artifacts/${BINARY} "s/^VERSION=.*/VERSION=\"v${VERSION}\"/"
 artifacts/${BINARY} -v | grep ${VERSION}
 popd

--- a/ci/settings.yml
+++ b/ci/settings.yml
@@ -15,3 +15,28 @@ meta:
   slack:
     webhook: FIXME
     channel: "#genesis"
+
+  dockerhub:
+    email: (( vault "secret/pipelines/genesis/dockerhub:email" ))
+    username: (( vault "secret/pipelines/genesis/dockerhub:username" ))
+    password: (( vault "secret/pipelines/genesis/dockerhub:password" ))
+    repository: starkandwayne/genesis
+
+jobs:
+  - name: shipit
+    plan:
+      - (( append ))
+      - put: genesis-image
+        params:
+          build: pushme/git
+          tag: version/number
+          tag_as_latest: true
+
+resources:
+  - name: genesis-image
+    type: docker-image
+    source:
+      email: (( grab meta.dockerhub.email ))
+      username: (( grab meta.dockerhub.username ))
+      password: (( grab meta.dockerhub.password ))
+      repository: (( grab meta.dockerhub.repository ))


### PR DESCRIPTION
This PR adds a Dockerfile in project root and a job to build said image in the pipeline.
A next step could be to use this image in the pipelines generated by genesis, but even without that this has merit.

Things gained by using a dedicated genesis image:
- easily playing around in an isolated environment with all deps in place
- self contained project including clear documentation of all deps (this could even be improved by using `FROM ubuntu` instead of `FROM concourse/concourse-ci` since all that brings is bosh_cli and it is likely that we want to controll updating the bosh_cli ourselves).
- traceability, easy tracking the history of deps, as requirements / versions change with the tool itself
- reduce responsibility of the starkandwayne/concourse image. The starkandwayne/concourse image has become a 'stuff all things we may need in here' image which makes it impossible to know the relationship between the tools inside it and the projects that use it. When taken to far this will be a source of technical debt when individual projects that use it diverge on their requirements. There is nothing wrong with having a go-to image to get started on a new project pipeline quickly that has only generic requirements. This project however has a focused scope and would benefit from being self contained.