### PR TITLE
Fix an issue with `genesis embed` permissions

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -2139,6 +2139,7 @@ cmd_embed() {
 
 	mkdir -p ${DEPLOYMENT_ROOT}/bin
 	cp ${BASH_SOURCE[0]} ${DEPLOYMENT_ROOT}/bin/genesis
+	chmod 755 ${DEPLOYMENT_ROOT}/bin/genesis
 
 	${DEPLOYMENT_ROOT}/bin/genesis version
 }


### PR DESCRIPTION
Previously, `genesis embed` would copy the source
file's permissions in place, if no genesis script
existed already in the deployment repo. When combined
with homebrew's genesis (permissions of 0555), this
meant subsequent `genesis embed`s would fail with
a `Permission Denied` error. Now, the embeded
copy is always 755 in the repo.