### PR TITLE
Update release/stemcell upload/version checking behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,3 +82,90 @@ If you have privileged access and wish to install Genesis for all
 users, you can put it in `/usr/local/bin` or `/usr/bin`
 
 [spruce]: https://github.com/geofffranks/spruce
+
+# Managing BOSH Release/Stemcell Versions with Genesis
+
+Genesis offers the following commands for manipulating release
+and stemcells globally, and across sites:
+
+| Command | Purpose |
+| ------- | ------- |
+| `genesis add release <release-name> [<version>]` | Adds the release to global/releases, at the specified version, or 'latest' if not specified |
+| `genesis use release <release-name>` | Adds the release to site/releases, so it gets included in environments of this site ||
+| `genesis set release <release-name> <version>` | Updates the release to the specified version at the global level |
+| `genesis use stemcell <stemcell-name/alias> <version>` | Sets the site's stemcell and version |
+
+### Stemcell Aliases
+
+To make working with stemcells easier, there are a few aliases built in for stemcells,
+so you don't need to remember/look up the full stemcell name for each architecture.
+Currently, they're all set to use the Ubuntu versions of the stemcell, so if you
+want CentOS, you'll need to specify the full name:
+
+| Alias | Stemcell |
+| ----- | -------- |
+| aws | bosh-aws-xen-hvm-ubuntu-trusty-go_agent |
+| azure | bosh-azure-hyperv-ubuntu-trusty-go_agent |
+| hyperv | bosh-azure-hyperv-ubuntu-trusty-go_agent |
+| openstack | bosh-openstack-kvm-ubuntu-trusty-go_agent |
+| vcloud | bosh-vcloud-esxi-ubuntu-trusty-go_agent |
+| vsphere | bosh-vsphere-esxi-ubuntu-trusty-go_agent |
+| warden | bosh-warden-boshlite-ubuntu-trusty-go_agent |
+| bosh-lite | bosh-warden-boshlite-ubuntu-trusty-go_agent |
+
+### Version Keywords
+
+Genesis allows you to specify some keywords for your release & stemcell
+versions, and attempts to make life easier for you where it can. Here's a
+run-down of the keywords, and how Genesis helps.
+
+#### track
+
+Specifying a version of `track` tells Genesis to fetch the latest version information
+from the [Genesis Index][genesis-index] whenever it's building the manifest. This way you will always
+get the latest version.
+
+This keyword is mostly useful for keeping stemcells up-to-date, when not using the
+`genesis ci` pipelines. When you use `genesis ci`, there is an automated task that
+monitors stemcells and propagates upgrades to them through your infrastructure, using
+explicit versions.
+
+#### latest
+
+This piggyback's on BOSH's `latest` version functionality. When specified, genesis
+will simply pass this version on to BOSH, to let BOSH chose the latest uploaded
+release/stemcell, and use that.
+
+If the release/stemcell does not exist yet on BOSH, Genesis will contact the [Genesis Index][genesis-index]
+and upload it for you, just-prior to deploying.
+
+This keyword cannot be used with bosh-init style deployments.
+
+#### x.y.z
+
+If you specify a raw version (3262.12, 241, 1.2.3), Genesis will tell BOSH to use that
+version explicitly. If you specify a sha1 and URL for the release/stemcell, BOSH will
+include that when it does the deploy. If you do not specify the sha1 or URL, Genesis
+will contact the [Genesis Index][genesis-index] to upload the release/stemcell,
+just prior to deploy. For bosh-init deployments, instead of uploading the release/stemcell,
+the sha1/url are saved to the local directory, since there isn't a BOSH to upload to.
+
+#### The Genesis Index
+
+The [Genesis Index][genesis-index] is a service designed to make managing releases and stemcells easier.
+It watches new versions of common releases and stemcells, and updates the index with
+their metadata. It is only contacted under the following circumstances:
+
+- When generating manifests for each stemcell/release that specified `track` as its version
+- When deploying a manifest which does not have a `sha1` or `url` attribute for a release/stemcell,
+  unless that release/stemcell is already present with the correct version on the BOSH director
+- When deploying a manifest which specifies `latest` as the version of a release/stemcell,
+  and that stemcell/release is not already present on the BOSH director.
+
+There is a wide range of commonly used releases already present in the [Genesis Index][genesis-index].
+If you need additional releases, feel free to submit a GitHub issue on the [genesis-index repo][genesis-index].
+If you have private releases that you wish to manage using the [Genesis Index][genesis-index], or cannot
+contact the public [Genesis Index][genesis-index], you can run your own internally, and specify the `$GENESIS\_INDEX`
+environment variable to override the default index.
+
+[genesis-index]: http://github.com/starkandwayne/genesis-index

--- a/bin/genesis
+++ b/bin/genesis
@@ -808,11 +808,7 @@ EOF
 	if [[ -f $HOME/.bosh_config ]] ; then
 		local director_uuid
 		local director_url=$(spruce json ~/.bosh_config | jq -r ".target")
-		local director_address=$(echo $director_url | sed -ne 's/^https\{0,1\}:\/\/\(.*\):[0-9]\{1,\}$/\1/p')
-		if [[ -n "$director_address" ]] &&\
-			 ping $director_address -c1 -W1 >/dev/null 2>&1 &&\
-			 curl -k -m5 ${director_url}/info >/dev/null 2>&1
-		then
+		if director_alive ${director_url}; then
 			director_uuid=$(bosh status --uuid)
 			if [[ $? == 0 && -n "${director_uuid}" ]] ; then
 				cat <<EOF > ${root}/director.yml
@@ -959,9 +955,9 @@ normal_site_metadata() {
 	if [[ ${stemcell_version} == "latest" ]]; then
 		rm -f ${DEPLOYMENT_ENV_DIR}/.site/stemcell/url
 		rm -f ${DEPLOYMENT_ENV_DIR}/.site/stemcell/sha1
-	else
-		check_index stemcell ${stemcell_name} ${stemcell_version}
 	fi
+
+	ensure_present stemcell ${stemcell_name} ${stemcell_version}
 
 	local stemcell_url=""
 	if [[ -f "${DEPLOYMENT_ENV_DIR}/.site/stemcell/url" ]]; then
@@ -992,9 +988,8 @@ normal_site_metadata() {
 		if [[ ${release_version} == "latest" ]]; then
 			rm -f ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/url
 			rm -f ${DEPLOYMENT_ENV_DIR}/.global/releases/${rel}/sha1
-		else
-			check_index release ${rel} ${release_version}
 		fi
+		ensure_present release ${rel} ${release_version}
 	done
 
 	cat <<EOF
@@ -1082,6 +1077,151 @@ build_manifest() {
 	if [[ $rc != 0 ]]; then
 		echo >&2 "Failed to merge templates; bailing..."
 		exit 5
+	fi
+}
+
+director_alive() {
+	director_url=$1; shift
+	local director_address=$(echo $director_url | sed -ne 's/^https\{0,1\}:\/\/\(.*\):[0-9]\{1,\}$/\1/p')
+	if [[ -n "$director_address" ]] &&\
+	 ping -c1 -W1 $director_address >/dev/null 2>&1 &&\
+	 curl -k -m5 ${director_url}/info >/dev/null 2>&1; then
+		return 0
+	else
+		return 1
+	fi
+}
+
+have_blob() {
+	local type=$1; shift
+	local name=$1; shift
+	local version=$1; shift
+
+	local director_url=$(spruce json ~/.bosh_config | jq -r ".target")
+	local director_creds=$(spruce json ~/.bosh_config | jq -r '.auth[.target].username + ":" + .auth[.target].password')
+	if director_alive $director_url; then
+		if [[ ${version} == "latest" ]]; then
+			if [[ ${type} == "release" ]]; then
+				if [[ -n $(curl -Lks --connect-timeout 1 -u "${director_creds}" ${director_url}/releases | jq -r '.[]| select(.name == "'${name}'") | "release-detected"') ]]; then
+					return 0
+				else
+					return 1
+				fi
+			elif [[ ${type} == "stemcell" ]]; then
+				if [[ -n $(curl -Lks --connect-timeout 1 -u "${director_creds}" ${director_url}/stemcells | jq -r '.[]| select(.name == "'${name}'") | "stemcell-detected"') ]]; then
+					return 0
+				else
+					return 1
+				fi
+			else
+				echo >&2 "Error: Invalid type. This is a bug. Got ${type} but expected 'stemcell' or 'release'"
+				exit 2
+			fi
+		else
+			if [[ ${type} == "release" ]]; then
+				if [[ -n $(curl -Lks --connect-timeout 1 -u "${director_creds}" ${director_url}/releases | jq -r '.[] | select(.name == "'${name}'") | .release_versions[] | select(.version == "'${version}'") | "release-version-detected"') ]]; then
+					return 0
+				else
+					return 1
+				fi
+			elif [[ ${type} == "stemcell" ]]; then
+				if [[ -n $(curl -Lks --connect-timeout 1 -u "${director_creds}" ${director_url}/stemcells | jq -r '.[]| select(.name == "'${name}'") | select(.version == "'${version}'") | "stemcell-version-detected"') ]]; then
+					return 0
+				else
+					return 1
+				fi
+			else
+				echo >&2 "Error: Invalid type. This is a bug. Got ${type} but expected 'stemcell' or 'release'"
+				exit 2
+			fi
+		fi
+	else
+		echo >&2 "Error: Could not contact ${director_url} to find release information"
+		exit 2
+	fi
+}
+
+ensure_present() {
+	local type=$1; shift
+	local name=$1; shift
+	local version=$1; shift
+	if [[ ${version} != "track" ]]; then
+		if [[ $ENSURE_PRESENT == "yes" ]]; then
+			if have_blob ${type} ${name} ${version}; then
+				echo >&2 Found ${type} ${name} ${version} on director
+				return 0
+			else
+				local root=""
+				case ${type} in
+				(stemcell)
+					root=${DEPLOYMENT_ENV_DIR}/.site/stemcell
+					;;
+				(release)
+					root=${DEPLOYMENT_ENV_DIR}/.global/releases/${name}
+					;;
+				(*)
+					echo >&2 "Invalid type '${type}' given to check_index.  Please file a bug"
+					exit 2
+					;;
+				esac
+
+				# if sha1 + url are specified, let bosh handle the uploads
+				if [[ ! -f ${root}/sha1 && ! -f ${root}/url ]]; then
+					echo >&2 "Uploading ${type} ${name}/${version} as it is required, but not present"
+					upload_blob ${type} ${name} ${version}
+				fi
+			fi
+		fi
+	else
+		echo >&2 ${type} ${name} ${version} is set to track from the index
+		check_index ${type} ${name} ${version}
+	fi
+}
+
+upload_blob() {
+	local type=$1; shift
+	local name=$1; shift
+	local version=$1; shift
+
+	if [[ -z ${GENESIS_INDEX} ]]; then
+		echo >&2 "Error: ${type} ${name}/${version} is not present on the BOSH director."
+		echo >&2 "       Please either \`bosh upload ${type}\` manually, or enable the"
+		echo >&2 "       Genesis index by setting the GENESIS_INDEX environment variable."
+		exit 2
+	fi
+
+	need_a_workdir
+
+	if [[ $version != "latest" ]]; then
+		version="v/${version}"
+	fi
+
+	echo >&2 "  checking ${GENESIS_INDEX} for details on ${type} ${name}/${version}"
+	if ! curl --fail -Lsk ${GENESIS_INDEX}/v1/${type}/${name}/${version} > ${WORKDIR}/index; then
+		echo >&2 "Unable to upload ${type} ${name}/${version} - could not find details on Genesis index"
+		echo >&2 "(at $GENESIS_INDEX)"
+		exit 2
+	fi
+
+	url=$(jq -r ".url" <${WORKDIR}/index)
+	if [[ -z ${url} ]]; then
+		echo >&2 "No URL found in the Genesis index for ${type}/${name}/${version}"
+		echo >&2 "(at $GENESIS_INDEX)"
+		echo >&2 "Either upload the ${type} manually, or add ${name} to the Genesis index."
+		exit 2
+	fi
+
+	desired_uuid=$(spruce json director.yml | jq -r '.director_uuid')
+	current_uuid=$(bosh status --uuid)
+	if [[ $desired_uuid != $current_uuid ]]; then
+		echo >&2 "Director UUID mismatch detected. You do not appear to be targeting"
+		echo >&2 "the director for this deployment (expected $desired_uuid, got $current_uuid)"
+		exit 2
+	fi
+	echo >&2 "Could not find ${type} ${name}/${version} on the director, uploading it for you"
+	if ! bosh upload "${type}" "${url}" >&2; then
+		echo >&2 "Failed to upload ${type} ${name}/${version}. Bailing out"
+		exit 2
 	fi
 }
 
@@ -2178,6 +2318,11 @@ cmd_deploy() {
 	[[ -z $1 ]] || bad_usage "deploy"
 
 	must_be_in_an_environment
+
+	# add flag to ensure that we're going to check/upload releases
+	# and stemcells if missing
+	ENSURE_PRESENT=yes
+
 	case ${DEPLOYMENT_TYPE} in
 	(normal)
 		(VAULT_ADDR= REDACT=y cmd_build manifest.yml) || exit 3

--- a/cheatsheet.md
+++ b/cheatsheet.md
@@ -24,6 +24,34 @@
 | Recreate a specific VM | `genesis bosh recreate api_z1/0` |
 | Run the smoke-tests BOSH errand | `genesis bosh run errand smoke-tests` |
 
+# Stemcell Aliases
+
+| Alias | Stemcell |
+| ----- | -------- |
+| aws | bosh-aws-xen-hvm-ubuntu-trusty-go_agent |
+| azure | bosh-azure-hyperv-ubuntu-trusty-go_agent |
+| hyperv | bosh-azure-hyperv-ubuntu-trusty-go_agent |
+| openstack | bosh-openstack-kvm-ubuntu-trusty-go_agent |
+| vcloud | bosh-vcloud-esxi-ubuntu-trusty-go_agent |
+| vsphere | bosh-vsphere-esxi-ubuntu-trusty-go_agent |
+| warden | bosh-warden-boshlite-ubuntu-trusty-go_agent |
+| bosh-lite | bosh-warden-boshlite-ubuntu-trusty-go_agent |
+
+# Version Keywords
+
+| Keyword | Behavior |
+| ------- | -------- |
+| track   | Always fetches and deploys the latest release/stemcell found on the Genesis Index |
+| latest | Use the latest version on the BOSH director. If none present, uploads the latest found on the Genesis Index |
+| 1.2.3 | Use version 1.2.3, uploading if necessary |
+
+# Environment Variables
+
+| GENESIS_INDEX=http://your.genesis.index.com | Overrides the default Gensis Index URL |
+| GENESIS_INDEX=no | Disables checking of the Genesis Index |
+| USE_SYSTEM_GENESIS | Overrides the `genesis` command from $PATH instead of the repo-embedded copy |
+| DEBUG=true | Turns on debugging for spruce when generating manifests |
+
 # Managing Genesis
 
 | How do I use Genesis to ... ? | Example |


### PR DESCRIPTION
Brings Genesis behavior inline with the rules set forth in #77.

Genesis will now auto-upload releases (if they don't exist), and no
sha1/url are present, when versions are latest, or a specific number.

If track is specified, it will behave the same.

Fixes #77.