### PR TITLE
Fix issue where stemcell/release version checking failed

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1102,13 +1102,13 @@ have_blob() {
 	if director_alive $director_url; then
 		if [[ ${version} == "latest" ]]; then
 			if [[ ${type} == "release" ]]; then
-				if [[ -n $(curl -Lks --connect-timeout 1 -u "${director_creds}" ${director_url}/releases | jq -r '.[]| select(.name == "'${name}'") | "release-detected"') ]]; then
+				if [[ -n $(curl -Lks -u "${director_creds}" ${director_url}/releases | jq -r '.[]| select(.name == "'${name}'") | "release-detected"') ]]; then
 					return 0
 				else
 					return 1
 				fi
 			elif [[ ${type} == "stemcell" ]]; then
-				if [[ -n $(curl -Lks --connect-timeout 1 -u "${director_creds}" ${director_url}/stemcells | jq -r '.[]| select(.name == "'${name}'") | "stemcell-detected"') ]]; then
+				if [[ -n $(curl -Lks -u "${director_creds}" ${director_url}/stemcells | jq -r '.[]| select(.name == "'${name}'") | "stemcell-detected"') ]]; then
 					return 0
 				else
 					return 1
@@ -1119,13 +1119,13 @@ have_blob() {
 			fi
 		else
 			if [[ ${type} == "release" ]]; then
-				if [[ -n $(curl -Lks --connect-timeout 1 -u "${director_creds}" ${director_url}/releases | jq -r '.[] | select(.name == "'${name}'") | .release_versions[] | select(.version == "'${version}'") | "release-version-detected"') ]]; then
+				if [[ -n $(curl -Lks -u "${director_creds}" ${director_url}/releases | jq -r '.[] | select(.name == "'${name}'") | .release_versions[] | select(.version == "'${version}'") | "release-version-detected"') ]]; then
 					return 0
 				else
 					return 1
 				fi
 			elif [[ ${type} == "stemcell" ]]; then
-				if [[ -n $(curl -Lks --connect-timeout 1 -u "${director_creds}" ${director_url}/stemcells | jq -r '.[]| select(.name == "'${name}'") | select(.version == "'${version}'") | "stemcell-version-detected"') ]]; then
+				if [[ -n $(curl -Lks -u "${director_creds}" ${director_url}/stemcells | jq -r '.[]| select(.name == "'${name}'") | select(.version == "'${version}'") | "stemcell-version-detected"') ]]; then
 					return 0
 				else
 					return 1

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Bug Fixes
+
+Fixed an issue where `genesis`'s automatic release/stemcell detection would fail sometimes
+due to slow connections to the BOSH director, or delays returning stemcell data.


### PR DESCRIPTION
The `--connect-timeout 1` flag on our `curl` calls to the BOSH director
to find existing release/stemcell information seems too agressive.
If there is a delay in the director responding to that request, it
caused `genesis` to try to upload the release/stemcell again, and fail.

Since prior to these `curls`, we have a failsafe switch checking to
ensure that the director is alive, the connect-timeout 1 doesn't buy us
anything but failures. If the director is down, the checks are
short-circuited entirely.