### PR TITLE
Redact  output

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -3839,7 +3839,7 @@ main() {
 		cmd_releases $*
 		;;
 	(build)
-		cmd_build $*
+		REDACT=y cmd_build $*
 		;;
 	(refresh)
 		local arg=${1:-all} ; shift


### PR DESCRIPTION
When `genesis build` was called explicitly, non-redacted manifests were built, as the REDACT environment variable was not set. `make manifest` sets `REDACT=y`, however that was only as of a specific version of genesis, that the makefiles did that. 

This has been added to close the loop on cases where older makefiles had not been updated, to prevent accidental credential committing after a `make manifest`