### PR TITLE
Added help for non-ci stuff

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1,5 +1,80 @@
 #!/bin/bash
+unset IFS
+
+# echo >&2 "======"$'\n'"DEBUG: called '${FUNCNAME[0]}' with "$'\n'" --($@)--"$'\n'"^^^^^^"
+: <<'dox-overview:genesis'
+USAGE
+@~include=usage{"cmd":"<command> [options] [arguments]"}
+
+DESCRIPTION
+	Genesis is a tool build around a BOSH deployment paradigm that allows you to
+	create and manage unified deployment manifests across multiple sites and
+	environments.
+
+	It does this by breaking up your BOSH configuration manifest along three
+	logical strata: global, site and environment.  This allows you to work on
+	small related blocks of elements, reducing complexity and redundancy, then
+	package them up for deployment across different IaaS providers and target
+	environments with properties appropriate for their needs.
+
+CONCEPTS
+@~include=topic{"category":"concept","leader":"    ","scope":"intro","desc":"block"}
+
+	More details are available for each concept by running
+	`<<SCRIPT_NAME>> help --concept <concept-name>`.
+
+COMMON COMMANDS
+@~include=topic{"category":"command","scope":"common","leader":"  genesis ","desc":"inline"}
+
+  For more details, run `genesis help <command>`
+dox-overview:genesis
+
+: <<'dox-concept:Makefiles'
+DESCRIPTION
+	When Genesis provisions a new environment, it creates a Makefile that
+	provides some easy "shortcut" command invocation targets to simplify the
+	manifest generation process.
+
+		make help
+			Displays this help content.
+
+		make version
+			Displays the version and location of the genesis executable that will be
+			used by the other make actions
+
+		make refresh
+			Pull in fresh copies of global and site YAML templates (into .global/ and
+			.site/).  This is a shortcut for `<<SCRIPT_NAME>> refresh all`
+
+		make manifest
+			Build a new manifest for the environment by merging the template YAML
+			files together.
+
+		make deploy
+			Build the manifest and attempt to deploy it.  This safely handles Vault'd
+			credentials by creating a separate manifest yaml file that only exists
+			for the duration of the deploy.
+
+	Since this is a real Makefile, you can combine the two actions.  For example:
+
+		make refresh manifest
+			Refresh global / site configuration, and then build an up-to-date
+			deployment manifest.
+
+SEE ALSO
+@~include=topic{"category":"concept","scope":"makefile","desc":"none","leader":"  <<SCRIPT_NAME>> help --concept "}
+
+COMMANDS
+@~include=topic{"category":"command","scope":"makefile","desc":"inline","leader":"  <<SCRIPT_NAME>> "}
+
+dox-concept:Makefiles
+
+( set -o posix ; set > /tmp/variables.$$)
+__debug_vars() {
+	diff /tmp/variables.$$ <(set -o posix; set) | grep '^[<>]'
+}
 VERSION="(development build)"
+SCRIPT_NAME=$0 # or $(basename $0) ?
 
 USERNAME=$(whoami)
 CANON_REPO=https://github.com/starkandwayne/genesis
@@ -169,8 +244,7 @@ setup() {
 
 	# What type of deployment is this?
 	#
-	#    normal    - A normal deployment
-	#    bosh      - A BOSH deployment (currently-favored type)
+	#    normal    - A normal BOSH deployment
 	#    bosh-init - A bosh-init BOSH deployment
 	#
 	DEPLOYMENT_TYPE=normal
@@ -417,7 +491,7 @@ else
 endif
 
 help: check
-	@PATH=\$(PATH) genesis help makefile
+	@PATH=\$(PATH) genesis help --concept Makefiles
 
 version:
 	@PATH=\$(PATH) echo "using \$\$(which genesis)"
@@ -497,7 +571,7 @@ create_global_readme() {
 Global Definitions
 
 This directory contains templates that describe the common elements of this
-deployments, to be shared (and possibly overridden) by sites and environments.
+deployment, to be shared (and possibly overridden) by sites and environments.
 The templates are merged in the following order:
 
   global/jobs.yml             Specify what jobs will make up the canonical
@@ -1352,21 +1426,36 @@ EOF
 	done
 }
 
-bad_usage() {
-	echo >&2 "USAGE: genesis $@"
-	exit 1
-}
-
-
 ####################################################
 # multi-call handlers
 
+: <<'dox-command:version'
+USAGE
+@~include=usage
+
+DESCRIPTION
+	Displays the version and checksum of the genesis executable.
+
+SEE ALSO
+@~include=related{"items":["command:update","command:embed"]}
+dox-command:version
 cmd_version() {
 	s=$(cat ${BASH_SOURCE[0]} | checksum)
 	echo "genesis ${VERSION} (${s:0:12})"
 	exit 0
 }
 
+: <<'dox-command:update'
+USAGE
+@~include=usage
+
+DESCRIPTION
+	Updates the version of the genesis executable to the latest release from the
+	genesis repo.
+
+SEE ALSO
+@~include=related{"items":["command:version","command:embed"]}
+dox-command:update
 cmd_update() {
 	need_a_workdir
 	curl -Ls $(curl -s ${API_REPO}/releases/latest | jq -r '.assets[] | select(.name | test("genesis")) | .browser_download_url') > ${WORKDIR}/bin
@@ -1381,268 +1470,269 @@ cmd_update() {
 	exit $?
 }
 
-cmd_help() {
-	local topic=""
-	while (( $# )); do
-		arg=$1 ; shift
-		case ${arg} in
-		(-*)
-			echo >&2 "USAGE: genesis help <topic>"
-			exit 1
-			;;
-		(*)
-			if [[ -n ${topic} ]]; then
-				topic="${topic} "
-			fi
-			topic="${topic}${arg}"
-		esac
-	done
+: <<'dox-command:embed'
+USAGE
+@~include=usage
 
-	case ${topic:-usage} in
-	(usage|help)
-		cat >&2 <<'EOF'
-USAGE: genesis <command> [arguments]
+DESCRIPTION
+	Embeds the version of `genesis' installed in your $PATH into your deployment
+	repo under /bin, so it can be used via the Makefile and Concourse tasks.
+	This will replace any version already embedded.
 
-Common commands:
+SEE ALSO
+@~include=related{"items":["command:version","command:update"]}
+dox-command:embed
+cmd_embed() {
+  [[ -z $1 ]] || bad_usage_no_args
 
-    genesis new deployment      Create a new deployment directory, with all the
-                                necessary files for deploying with Genesis.
+  echo "Embedding genesis script into repository"
+  setup
 
-                                Specifying `--template' tells genesis to create your
-                                deployment directory based on the specified template repo.
+  mkdir -p ${DEPLOYMENT_ROOT}/bin
+  cp ${BASH_SOURCE[0]} ${DEPLOYMENT_ROOT}/bin/genesis
+  chmod 755 ${DEPLOYMENT_ROOT}/bin/genesis
 
-    genesis new site            Set up the files and directories for a new site.
-                                Specifying `--template' tells genesis to create the
-                                site directory based on the specified IaaS templates.
-
-                                See the `.templates' directory at the root of your
-                                deployment repo for valid options.
-
-    genesis new environment     Set up the files and directories for a new environment.
-
-                                Specifying `--type' of `bosh-init' will tell genesis
-                                to treat this specific environment as a bosh-init type
-                                deployment. Useful if you need to use bosh-init for some
-                                environments, but regular BOSH deployments for others.
-
-    genesis stemcells           Lists the stemcell name + version in use by the
-                                specified site or environment. If no arguments are
-                                specified, you must be in a site/environment directory.
-
-    genesis releases            Lists the release name and version in use by the
-                                specified site or environment. If no arguments are
-                                specified, you must be in a site/environment directory.
-
-    genesis add release         Adds release definitions to the global configurations
-                                for the specified release and optionally, its version.
-
-    genesis set release         Updates the specified release to the specified version,
-                                globally.
-
-    genesis use release         When inside a site or environment directory, takes
-                                the provided release name, and configures the site
-                                to include the release when deploying to environments
-                                in that site.
-
-    genesis use stemcell        When inside a site or environment directory, takes
-                                the provided stemcell name, and updates the site
-                                directory to use that stemcell. You can optionally
-                                specify the version of the stemcell to be used as
-                                a second argument after the stemcell name.
-
-    genesis build               When run from inside of an environment directory,
-                                paste together all of the template files, in order
-                                and pop out a manifest file.
-
-    genesis deploy              When run from inside of an environment directory,
-                                builds and deploys your BOSH manifest. A redacted
-                                copy is left in the repo for posterity. The copy
-                                deployed is non-redacted.
-
-    genesis diff                When run from inside of an environment directory,
-                                show a semantic diff of the generated manifest for that
-                                environment, against some other manifest file.
-
-    genesis refresh             Refresh the cached copies of site and/or global
-                                definitions inside the current environment directory.
-                                Can also be used to recreate the Makefile after a
-                                Genesis upgrade.
-
-                                Use `genesis refresh <site|global|makefile|readme>'
-                                to specify what to refresh.
-
-    genesis embed               Embeds the version of `genesis' installed in your $PATH
-                                into your deployment repo, so it can be used via the Makefile
-                                and Concourse tasks.
-
-    genesis bosh                Generates a deployable manifest (which may have secrets
-                                in it) and then runs the `bosh' CLI with remaining
-                                arguments.  Useful for recreating workers.
-
-    genesis help                Peruse the help!  Give it a topic argument, or the name
-                                of another command to get more detailed information.
-                                Documentation!
-
-EOF
-		exit 0
-		;;
-	(new)
-		cat >&2 <<EOF
-USAGE: genesis new deployment [options] NAME
-       genesis new site [options] SITE
-       genesis new environment SITE ENVIRONMENT
-
-Creates new things, with all the right files in all the right places.
-
-EOF
-		exit 0
-		;;
-	(new\ deployment)
-		cat >&2 <<EOF
-USAGE: genesis new deployment [options] NAME
-       genesis new deployment --template TEMPLATE [NAME]
-
-  Create a new deployment, complete with all the correct templates in
-  global/, and a base configuration.  This will create a sub-directory
-  in the current working directory, named <NAME>-deployments, and set
-  it up with git version control.
-
-  OPTIONS
-
-    -t, --type <type>
-
-        Generate a different type of deployment.  Valid values are
-        'bosh-init' and 'normal' (the default is 'normal').
-
-    -T, --template <name>
-
-        Base the deployment off of an upstream Genesis template, by
-        cloning a repository from github.com and using that.
-
-        Templates can be specified as qualified name containing the
-        Github org/user and repository name, i.e. "jhunt/bolo", or
-        as a simple name, i.e. "shield", which will be inferred to
-        belong to the starkandwayne organization.
-
-EOF
-		exit 0
-		;;
-	(new\ site)
-		cat >&2 <<EOF
-USAGE: genesis new site [options] NAME
-
-  Create a new site with the given name, and set up the necessary
-  directories and blank template files for defining the parts of a
-  BOSH manifest that map to infrastructural and site-wide things.
-
-  OPTIONS
-
-    -T, --template <name>
-
-        Base the new site off of a site template.
-
-        This generally only works if you generated the deployment
-        from an upstream Genesis template (via '--template')
-
-EOF
-		exit 0
-		;;
-	(new\ environment)
-		cat >&2 <<EOF
-USAGE: genesis new environment SITE NAME
-
-  Create a new environment with the given name, in the specified
-  site, and set up the directories and template files for local,
-  environment-specific things.
-
-EOF
-		exit 0
-		;;
-	(build)
-		cat >&2 <<EOF
-USAGE: genesis build
-
-Compiles all of the YAML templates down to a single BOSH manifest
-for the current environment.
-
-EOF
-		exit 0
-		;;
-	(refresh)
-		cat >&2 <<EOF
-USAGE: genesis refresh [(global|site|all|makefile|readme)]
-
-Copies current definitions of the global templates and/or the
-current site into the current environment.  By default, copies both.
-
-The argument 'makefile' only rebuilds the Makefile for an environment,
-which can be useful to bring old deployments in-line with newer versions
-of Genesis.
-
-Similarly, 'readme' only recreates the various README files for the top-level,
-the global/ directories, and all sites and environments.
-
-EOF
-		exit 0
-		;;
-	(makefile)
-		cat >&2 <<EOF
-When Genesis provisions a new environment, it creates a Makefile that
-provides some easy "shortcut" command invocation targets to simplify
-the manifest generation process.
-
-  $ make manifest           #  Build a new manifest for the environment
-                            #  by merging the template YAML files together.
-
-  $ make deploy             # Build the manifest and attempt to deploy it.
-                            # (This safely handles Vault'd credentials)
-
-  $ make refresh            #  Pull in fresh copies of global and site YAML
-                            #  templates (into .global/ and .site/).
-
-Since this is a real Makefile, you can combine the two actions:
-
-  $ make refresh manifest   #  Refresh global / site configuration and then
-                            #  build an up-to-date deployment manifest.
-
-EOF
-		exit 0
-		;;
-	(bosh)
-		cat >&2 <<EOF
-USAGE: genesis bosh [...]
-
-Generates a deployable manifest (which may contain credentials or other
-secrets) and then passes the remaining arguments off to the \`bosh\` CLI.
-
-For example, to rebuild the worker/1 job:
-
-    $ genesis bosh -t prod recreate worker 1
-
-All other BOSH commands are available, but may not necessarily benefit
-from the manifest re-generation step.
-
-EOF
-		exit 0
-		;;
-	# FIXME: ci
-	(*)
-		cat >&2 <<EOF
-Unrecognized help topic '${topic}'.
-Try one of these:
-
-    genesis help usage
-    genesis help <command>
-
-EOF
-		exit 0
-		;;
-	esac
-	exit 1
+  ${DEPLOYMENT_ROOT}/bin/genesis version
 }
 
+: <<'dox-concept:Structure'
+DESCRIPTION
+  Genesis organizes the files used to build your manifests into logical
+  locations based on hierarchial and functional scope.
+
+  Each genesis-generated deployment repository contains the YAML templates that
+  contain the details required to create the BOSH deployment manifest across
+  one or more sites and environments.
+
+  The configuration is broken up into three logical strata: global,
+  site, and environment:
+
+    global:
+      Defines the universal aspects of any deployment, including overall job
+      structure, constituent BOSH releases, and invariant (or default)
+      properties.
+
+    site:
+      represents a single IaaS (an AWS VPC, a vSphere cluster, etc.), and
+      further refines the global configuration for that infrastructure.
+
+    environment:
+      represents a single BOSH deployment, with specific network numbering,
+      credentials, domain names, etc.
+
+  Directory Structure
+  -------------------
+
+  <software>-deployments
+  |-- README.md
+  |-- bin
+  |   `-- genesis
+  |-- global
+  |   |-- README
+  |   |-- deployment.yml
+  |   |-- jobs.yml
+  |   |-- properties.yml
+  |   `-- releases
+  |       |-- <release-name-1>
+  |       |   |-- sha1
+  |       |   |-- url
+  |       |   `-- version
+  |       `-- <release-name-2>
+  |           `-- version
+  `-- <site-name-1>
+      |-- <environment-name-1>
+      |   |-- Makefile
+      |   |-- README
+      |   |-- cloudfoundry.yml
+      |   |-- credentials.yml
+      |   |-- director.yml
+      |   |-- manifests
+      |   |   `-- manifest.yml
+      |   |-- monitoring.yml
+      |   |-- name.yml
+      |   |-- networking.yml
+      |   |-- properties.yml
+      |   `-- scaling.yml
+      `-- site
+          |-- README
+          |-- disk-pools.yml
+          |-- jobs.yml
+          |-- networks.yml
+          |-- properties.yml
+          |-- releases
+          |-- resource-pools.yml
+          |-- stemcell
+          |   |-- name
+          |   `-- version
+          `-- update.yml
+
+  Global Definitions
+  ------------------
+
+  The `global` directory contains templates that describe the common elements
+  of all deployments for this software, to be shared (and possibly overridden)
+  by sites and environments.  The templates are merged in the following
+  order:
+
+    jobs.yml:       Specify what jobs will make up the canonical deployment,
+                    and what templates to apply to them.
+
+    deployment.yml: Define the global structure of all deployments with the
+                    correct param calls to remind template writers to override
+                    the correct things.
+
+    properties.yml: Define the properties for this deployment.  This can be
+                    done on a per-job basis, or under the top-level properties
+                    key.
+
+    releases:       This directory contains a directory for each release used
+                    by the deployment.  These should not be modified by hand,
+                    but instead using the `(add|set|use) release` commands. See
+                    help for `Releases` for more information.
+
+  NOTE:
+    If you make changes to the templates in here, they will automatically
+    propagate to any newly-created environments, but you will need to run a
+    refresh for existing environments to receive those updates.
+
+  Site Definitions
+  ----------------
+
+  All directories found at the root of the repository that themselves contain
+  a directory called `site` are considered sites.  This is usually used to
+  describe infrastructure-specific settings and site-wide properties, although
+  you can have multiple sites that run under the same infrastructure.  The
+  templates are merged in the following order:
+
+    disk-pools.yml:     If you are using disk pools, put disk pool definitions
+                        in this file.
+
+    update.yml:         Specify job update parameters here, which can change
+                        based on the cloud provider in use, and its performance
+                        characteristics.
+
+    jobs.yml:           Here you can modify the list of jobs defined at the
+                        global level, remove jobs (by setting their instances:
+                        count to 0), and supply any additional, site-wide job
+                        properties.
+
+    networks.yml:       Define what networks to use for all the environments in
+                        this site (although you may want to defer the actual
+                        numbering to the environment level.
+
+    resource-pools.yml: Set up the resource pools to use for job virtual
+                        machines, and apply their cloud properties (i.e.
+                        availability zones)
+
+    properties.yml:     Define properties (both globally and per-job), that are
+                        specific to this environment.  These will most likely
+                        override global properties.
+
+  NOTE:
+    If you make changes to the templates in here, they will automatically
+    propagate to any newly-created environments, but you will need to run a
+    refresh for existing environments to receive those updates.
+
+  Environment Definitions
+  -----------------------
+
+  All other directories that are siblings to the `site` directory represent a
+  single environment to be deployed.  Each one contains templates that describe
+  the environment-specific settings of a single deployment.  These templates
+  will be combined with the global and site templates to produce a single BOSH
+  manifest for deployment purposes.  The templates are merged in the following
+  order:
+
+    monitoring.yml:   Configure whatever (external) monitoring system you want
+                      to track the performance and health of your deployment.
+
+    networking.yml:   Configure the network numbering for this deployment.
+
+    director.yml:     Identify the BOSH director UUID for this deployment.
+
+    scaling.yml:      Define the scaling properties for this deployment,
+                      including things like the number of instances, sizes of
+                      persistent disks, resource pool limits, etc.
+
+    properties.yml:   Define properties (both globally and per-job), that are
+                      specific to this environment.  These will most likely
+                      override global and site properties.
+
+    credentials.yml:  Define passwords and credentials here, so that they are
+                      centralized.  Keep in mind that commiting these into
+                      version control incurs some security risk.
+
+    cloudfoundry.yml: For deployments that integrate with Cloud Foundry
+                      installations (i.e. as service brokers), you can specify
+                      the integration details here, including things like the
+                      CF API, credentials, domains, etc.
+
+    name.yml:         Specify the name of this deployment.
+
+  This directory also contains a Makefile that makes it easier to build the
+  final BOSH manifest from all of the constituent templates.  See help for
+  `Makefiles`for more information.
+
+COMMANDS
+@~include=topic{"category":"command","scope":"structure","leader":"  <<SCRIPT_NAME>> ","desc":"inline"}
+
+dox-concept:Structure
+
+: <<'dox-concept:Structure-bosh-init'
+DESCRIPTION
+  Genesis can be used to create manifests that can standup a BOSH director
+  using bosh-init.
+
+TODO: Fill in info on how to do this.
+dox-concept:Structure-bosh-init
+
+: <<'dox-partial:new'
+DESCRIPTION
+  Creates new things, with all the right files in all the right places.
+dox-partial:new
+
+: <<'dox-command:new-deployment'
+USAGE
+@~include=usage{"args":"[-t <type>] [-T <template>] [-r <dir>] <name>"}
+
+DESCRIPTION
+	Create a new deployment directory, with all the necessary files for deploying
+	with Genesis.
+
+	Specifying `--template' tells genesis to create your deployment directory
+	based on the specified template repo.
+
+OPTIONS
+	-t, --type <type>
+		Generate a different type of deployment.  Valid values are 'normal' and
+		'bosh' (or 'bosh-init'). The default is 'normal'.
+
+	-T, --template <name>
+		Base the deployment off of an upstream Genesis template, by cloning a
+		repository from github.com and using that.
+
+		Templates can be specified as qualified name containing the Github org/user
+		and repository name, i.e. "jhunt/bolo", or as a simple name, i.e. "shield",
+		which will be inferred to belong to the starkandwayne organization.
+
+	-r, --root <dirname>
+		The root directory under which to create the new deployment structure.
+		Defaults to the current directory.
+
+ARGUMENTS
+	name
+		The name of the deployment to be created.  This will result in a directory
+		called <name>-deployments
+
+SEE ALSO
+@~include=related{"items":["command:new site","command:new environment"]}
+
+@~include=related{"items":["concept:Structure","concept:Structure bosh-init"]}
+
+@~scope=common,structure
+dox-command:new-deployment
+
 cmd_new_deployment() {
-	local USAGE="new deployment [-t type] [-T template] [-r root/dir] <name>"
 	local dtype="normal"
 	local root=$(pwd)
 	local name=""
@@ -1652,24 +1742,21 @@ cmd_new_deployment() {
 		arg=$1 ; shift
 		case ${arg} in
 		(-t|--type)
+			check_opt_usage "$arg" "$1"
 			dtype=$1
-			[[ -n ${dtype} ]] || bad_usage ${USAGE}
 			shift
 			;;
 		(-T|--template)
+			check_opt_usage "$arg" "$1"
 			template=$1
-			[[ -n ${template} ]] || bad_usage ${USAGE}
 			shift
 			;;
 		(-r|--root)
+			check_opt_usage "$arg" "$1"
 			root=$1
-			[[ -n ${root} ]] || bad_usage ${USAGE}
 			shift
 			;;
-		(-*)
-			bad_usage ${USAGE}
-			exit 1
-			;;
+		(-*) bad_usage_invalid_opt "$arg" ;;
 		(*)
 			name=${arg%-deployment*}
 			shift
@@ -1688,7 +1775,7 @@ cmd_new_deployment() {
 			name=${name%%-deployment*}
 		fi
 	fi
-	[[ -n ${name:-} ]] || bad_usage ${USAGE}
+	[[ -n ${name:-} ]] || bad_usage_missing "deployment name"
 
 	if [[ ! -d ${root} ]]; then
 		echo >&2 "Error: root directory ${root} does not exist"
@@ -1720,12 +1807,12 @@ cmd_new_deployment() {
 	fi
 
 	case ${dtype} in
-	(bosh) dtype=bosh-init ;;
-	(normal|bosh-init) ;;
-	(*)
-		echo >&2 "Error: unrecognized deployment type '${dtype}'"
-		exit 1
-		;;
+		(normal|bosh-init) ;;
+		(bosh) dtype=bosh-init ;;
+		(*)
+			echo >&2 "Error: unrecognized deployment type '${dtype}'"
+			exit 1
+			;;
 	esac
 
 	DEPLOYMENT_TYPE=${dtype}
@@ -1759,8 +1846,41 @@ EOF
 	exit 0
 }
 
+: <<'dox-command:new-site'
+USAGE
+@~include=usage{"args":"[-T <template>] <name>"}
+
+DESCRIPTION
+	Sets up the files and directories for a new site.
+
+	When run, this command creates a new site with the given name, and set up the
+	necessary directories and blank template files for defining the parts of a
+	BOSH manifest that map to infrastructural and site-wide things.
+
+	Specifying `--template' tells genesis to create the
+	site directory based on the specified IaaS templates.
+
+OPTIONS
+	-T, --template <name>
+		Base the new site off of a site template.  This generally only works if you
+		generated the deployment from an upstream Genesis template (via
+		'--template')
+
+		See the `.templates' directory at the root of your
+		deployment repo for valid options.
+
+ARGUMENTS
+	name
+		The name of the site being created.  This is usually discriptive of a data
+		center or cloud provider, such as `aws-us-east` or `myOrg-myDC-vsphere`
+
+SEE ALSO
+@~include=related{"items":["command:new deployment","command:new environment"]}
+
+@~scope=common,structure
+dox-command:new-site
+
 cmd_new_site() {
-	local USAGE="new site [-T template] <name>"
 	local name=""
 	local template=""
 
@@ -1772,14 +1892,14 @@ cmd_new_site() {
 			shift
 			;;
 		(-*)
-			bad_usage ${USAGE}
+			bad_usage_invalid_opt "$arg"
 			;;
 		(*)
 			name=${arg}
 			;;
 		esac
 	done
-	[[ -n ${name} ]] || bad_usage ${USAGE}
+	[[ -n ${name} ]] || bad_usage_missing "site name"
 
 	setup
 	if [[ -d "${DEPLOYMENT_ROOT}/${name}" ]]; then
@@ -1818,8 +1938,43 @@ cmd_new_site() {
 	exit 0
 }
 
+: <<'dox-command:new-environment'
+USAGE
+@~include=usage{"args":"[-t <type>] <site> <name>","cmd":"new env[ironment]"}
+@~alias=new-env
+
+DESCRIPTION
+	Set up the files and directories for a new environment.
+
+	When run, this command creates a new environment with the given name, in the
+	specified site, and set up the directories and template files for local,
+	environment-specific things.
+
+	Specifying `--type' of `bosh-init' will tell genesis to treat this specific
+	environment as a bosh-init type deployment. Useful if you need to use
+	bosh-init for some environments, but regular BOSH deployments for others.
+
+OPTIONS
+	-t, --type <type>
+		Generate a different type of deployment.  Valid values are 'bosh-init' for
+		a bosh-init environment, 'bosh' which is an abreviation for 'bosh-init',
+		and 'normal' for standard bosh deployments (the default is 'normal') .
+
+ARGUMENTS
+	site (optional if in a site directory, required otherwise)
+		The name of the site under which the environment is being created.
+	name
+		The name of the environment being created.  This is usually discriptive of
+		a data center or cloud provider, such as `aws-us-east` or
+		`myOrg-myDC-vsphere`
+
+SEE ALSO
+@~include=related{"items":["command:new deployment","command:new site"]}
+
+@~scope=common,structure
+dox-command:new-environment
+
 cmd_new_environment() {
-	local USAGE="new environment [site] name"
 	local dtype site name
 	while (( $# )); do
 		arg=$1 ; shift
@@ -1827,23 +1982,21 @@ cmd_new_environment() {
 		(-t|--type)
 			dtype=$1
 			case ${dtype} in
-			(bosh) dtype=bosh-init ;;
 			(normal|bosh-init) ;;
-			(*) echo >&2 "Unrecognized deployment type: ${dtype}"
+			(bosh) dtype=bosh-init ;;
+			(*) echo >&2 "unrecognized deployment type: ${dtype}"
 			    exit 1 ;;
 			esac
 			shift
 			;;
-		(-*)
-			bad_usage ${USAGE}
-			;;
+		(-*) bad_usage_invalid_opt "$arg" ;;
 		(*)
 			if [[ -z ${site} ]]; then
 				site=${arg}
 			elif [[ -z ${name} ]]; then
 				name=${arg}
 			else
-				bad_usage ${USAGE}
+				bad_usage_extra "$arg"
 			fi
 			;;
 		esac
@@ -1856,12 +2009,8 @@ cmd_new_environment() {
 	fi
 
 	case ${dtype:-$DEPLOYMENT_TYPE} in
-	(normal)
-		create_normal_environment ${site} ${name}
-		;;
-	(bosh-init)
-		create_bosh_init_environment ${site} ${name}
-		;;
+		(normal)    create_normal_environment ${site} ${name} ;;
+		(bosh-init) create_bosh_init_environment ${site} ${name} ;;
 	esac
 
 	if [[ -n ${dtype} ]]; then
@@ -1869,15 +2018,6 @@ cmd_new_environment() {
 	fi
 
 	exit 0
-}
-
-bad_new() {
-	local arg=${1}
-	cat >&2 <<EOF
-USAGE: genesis new deployment
-       genesis new (site|environment)
-EOF
-	exit 1
 }
 
 check_index() {
@@ -1939,30 +2079,138 @@ check_index() {
 	fi
 }
 
+: <<'dox-concept:Releases'
+DESCRIPTION
+	TODO: Add details on how releases are handled
+
+Details on whats in the release directory, what's in the directory named for the desired release and what version sha1 and url files are for.
+explain how to support multiple releases and release propagation, link to see also Refreshing.
+
+COMMANDS
+@~include=topic{"category":"command","scope":"releases","desc":"inline","leader":"  <<SCRIPT_NAME>> "}
+
+dox-concept:Releases
+
+: <<'dox-command:releases'
+USAGE
+@~include=usage{"args":"[<site> [<env>]]","cmd":"release[s]"}
+@~alias=release
+
+DESCRIPTION
+	Lists the release name and version in use by the specified site or
+	environment. If no arguments are specified, you must be in a site/environment
+	directory.
+
+ARGUMENTS
+	site (optional)
+		if this is the sole argument, the releases used by the named
+		site will be displayed.  This is identical to the behaviour when run in
+		a site directory with no arguments.
+
+		Note: If in an environment directory, and just the site argument is
+		supplied, it will display the releases for the environment of the same
+		name as the current environment directory under the given site.
+
+	env (optional)
+		will show the releases used by the specified environment
+		under the given site.  This is identical to if no arguments are given
+		when run from an environment directory.
+
+SEE ALSO
+@~include=related{"items":["concept:Releases","command:add release","command:set release", "command:use release"]}
+@~scope=common,releases
+dox-command:releases
+cmd_releases() {
+	local site env
+	while (( $# )); do
+		arg=$1 ; shift
+		case ${arg} in
+		(-*) bad_usage_no_opts ;;
+		(*)
+			if [[ -z ${site} ]]; then  site=${arg}
+			elif [[ -z ${env} ]]; then env=${arg}
+			else bad_usage_extra "$arg"
+			fi
+			;;
+		esac
+	done
+
+	setup
+	site=${site:-$DEPLOYMENT_SITE}
+	env=${env:-$DEPLOYMENT_ENVIRONMENT}
+
+	if [[ -n ${env} ]]; then
+		for rel in $(releases_for_environment ${site} ${env}); do
+			vers=$(cat ${DEPLOYMENT_ROOT}/${site}/${env}/.global/releases/${rel}/version)
+			printf "%s/%s\n" ${rel} ${vers}
+		done
+		return
+	fi
+
+	if [[ -n ${site} ]]; then
+		for rel in $(releases_for_site ${site}); do
+			vers=$(cat ${DEPLOYMENT_ROOT}/global/releases/${rel}/version)
+			printf "%s/%s\n" ${rel} ${vers}
+		done
+		return
+	fi
+
+	bad_usage
+	exit 1
+}
+: <<'dox-command:add-release'
+USAGE
+@~include=usage{"args":"<name> [<version> [<url>]]"}
+
+DESCRIPTION
+	 Adds release definitions to the global configurations for the specified
+	 release and optionally, its version.
+
+ARGUMENTS
+	name
+		This is the name of the release
+
+	version (optional)
+		The version of the release that is to be used.  If not specified, it will
+		default to `latest`.  The valid values are:
+
+			`latest`:  use the latest version that is already available on the BOSH
+								 director.  this may not be the latest version that exists for
+								 this release at its source.
+
+			`track`:   use the version specified in the Genesis Index, which tracks
+								 accepted release versions.
+
+			<version>: A cardinal or SemVer value for the exact release you want to
+								 use, without any prefix such as 'v'
+
+	url
+		Specify the URL where the release is found, including the schema and the
+		version.  For example:
+		  https://bosh.io/d/github.com/myorg/mystuff-boshrelease?v=1.2.3
+
+SEE ALSO
+@~include=related{"items":["concept:Releases","command:releases","command:set release","command:use release"]}
+@~scope=common,releases
+dox-command:add-release
+
 cmd_add_release() {
-	local USAGE="add release <name> [<version> [<url>]]"
 	local release version url
 
 	while (( $# )); do
 		arg=$1 ; shift
 		case ${arg} in
-		(-*)
-			bad_usage ${USAGE}
-			;;
+		(-*) bad_usage_no_opts ;;
 		(*)
-			if [[ -z ${release} ]]; then
-				release=${arg}
-			elif [[ -z ${version} ]]; then
-				version=${arg}
-			elif [[ -z ${url} ]]; then
-				url=${arg}
-			else
-				bad_usage ${USAGE}
+			if [[ -z ${release} ]]; then   release=${arg}
+			elif [[ -z ${version} ]]; then version=${arg}
+			elif [[ -z ${url} ]]; then     url=${arg}
+			else bad_usage_extra "$arg"
 			fi
 			;;
 		esac
 	done
-	[[ -n ${release} ]] || bad_usage ${USAGE}
+	[[ -n ${release} ]] || bad_usage_missing "name"
 	version=${version:-latest}
 
 	setup
@@ -1991,42 +2239,68 @@ cmd_add_release() {
 	exit 0
 }
 
-bad_add() {
-	local arg=${1}
-	cat >&2 <<EOF
-USAGE: genesis add release
-EOF
-	exit 1
-}
+: <<'dox-command:set-release'
+USAGE
+@~include=usage{"args":"<name> [<version> [<url>]]"}
 
+DESCRIPTION
+	Updates the specified release to the specified version at the global level.
+
+ARGUMENTS
+	name
+		This is the name of the release
+
+	version (optional)
+		The version of the release that is to be used.  If not specified, it will
+		default to `latest`.  The valid values are:
+
+			`latest`:  use the latest version that is already available on the BOSH
+								 director.  this may not be the latest version that exists for
+								 this release at its source.
+
+			`track`:   use the version specified in the Genesis Index, which tracks
+								 accepted release versions.
+
+			<version>: A cardinal or SemVer value for the exact release you want to
+								 use, without any prefix such as 'v'
+
+	url
+		Specify the URL where the release is found, including the schema and the
+		version.  For example:
+		  https://bosh.io/d/github.com/myorg/mystuff-boshrelease?v=1.2.3
+
+SEE ALSO
+@~include=related{"items":["concept:Releases","command:releases","command:add release","command:use release"]}
+	name
+@~scope=common,releases
+dox-command:set-release
 cmd_set_release() {
-	local USAGE="set release <name> [<version>]"
 	local release version
 
 	while (( $# )); do
 		arg=$1 ; shift
 		case ${arg} in
 		(-*)
-			bad_usage ${USAGE}
+			bad_usage
 			;;
 		(*)
-			if [[ -z ${release} ]]; then
-				release=${arg}
-			elif [[ -z ${version} ]]; then
-				version=${arg}
-			else
-				bad_usage ${USAGE}
+			if [[ -z ${release} ]]; then   release=${arg}
+			elif [[ -z ${version} ]]; then version=${arg}
+			elif [[ -z ${url} ]]; then     url=${arg}
+			else bad_usage_extra "$arg"
 			fi
 			;;
 		esac
 	done
-	[[ -n ${release} ]] || bad_usage ${USAGE}
+	[[ -n ${release} ]] || bad_usage_missing "name"
 	version=${version:-track}
 
 	setup
 	mkdir -p ${DEPLOYMENT_ROOT}/global/releases/${release}
-	rm -rf ${DEPLOYMENT_ROOT}/global/releases/${release}/*
+	rm -rf   ${DEPLOYMENT_ROOT}/global/releases/${release}/*
 	echo ${version} > ${DEPLOYMENT_ROOT}/global/releases/${release}/version
+
+	[[ -n ${url} ]] && echo ${url} > ${DEPLOYMENT_ROOT}/global/releases/${release}/url
 
 	case ${version} in
 	(latest)
@@ -2050,26 +2324,38 @@ EOF
 	exit 1
 }
 
+: <<'dox-command:use-release'
+USAGE
+@~include=usage{"args":"<name>"}
+
+DESCRIPTION
+	 When inside a site or environment directory, takes the provided release
+	 name, and configures the site to include the release when deploying to
+	 environments in that site.
+
+ARGUMENTS
+	name
+		This is the name of the release to use.  Do not include the version.
+
+SEE ALSO
+@~include=related{"items":["concept:Releases","command:releases","command:add release","command:set release"]}
+
+@~scope=common,releases
+dox-command:use-release
 cmd_use_release() {
-	local USAGE="use release <name>"
 	local release
 
 	while (( $# )); do
 		arg=$1 ; shift
 		case ${arg} in
-		(-*)
-			bad_usage ${USAGE}
-			;;
+		(-*) bad_usage_invalid_opt "$arg" ;;
 		(*)
-			if [[ -z ${release} ]]; then
-				release=${arg}
-			else
-				bad_usage ${USAGE}
-			fi
+			[[ -z ${release} ]] || bad_usage_extra "$arg" "name" "$release"
+			release=${arg}
 			;;
 		esac
 	done
-	[[ -n ${release} ]] || bad_usage ${USAGE}
+	[[ -n ${release} ]] || bad_usage_missing "release name"
 
 	must_be_in_a_site
 	if [[ ! -d ${DEPLOYMENT_ROOT}/global/releases/${release} ]]; then
@@ -2088,15 +2374,148 @@ cmd_use_release() {
 	exit 0
 }
 
+: <<'dox-concept:Stemcells'
+DESCRIPTION
+	Talk about stemcells
+
+COMMANDS
+@~include=topic{"category":"command","scope":"stemcells","desc":"inline","leader":"  <<SCRIPT_NAME>> "}
+@~scope=stemcells
+dox-concept:Stemcells
+
+: <<'dox-command:stemcells'
+USAGE
+	<<SCRIPT_NAME>> stemcells [<site> [<env>]]
+
+DESCRIPTION
+	Lists the stemcell name + version in use by the specified site or
+	environment.  If no arguments are specified, you must be in a
+	site/environment directory.
+
+ARGUMENTS
+	site (optional)
+		if this is the sole argument, the stemcell used by the named site will be
+		displayed.  This is identical to the behaviour when run in a site directory
+		with no arguments.
+
+		Note: If in an environment directory, and just the site argument is
+		supplied, it will display the stemcell for the environment of the same name
+		as the current environment directory under the given site.
+
+	env (optional)
+		will show the stemcell used by the specified environment under the given
+		site.  This is identical to if no arguments are given when run from an
+		environment directory.
+
+SEE ALSO
+@~include=related{"items":["concept:Stemcells","command:use stemcell"]}
+@~scope=common,stemcells
+dox-command:stemcells
+
+cmd_stemcells() {
+	local site env
+	while (( $# )); do
+		arg=$1 ; shift
+		case ${arg} in
+		(-*) bad_usage_no_opts ;;
+		(*)
+			if [[ -z ${site} ]]; then  site=${site}
+			elif [[ -z ${env} ]]; then env=${arg}
+			else bad_usage_extra "$arg"
+			fi
+			;;
+		esac
+	done
+
+	setup
+	site=${site:-$DEPLOYMENT_SITE}
+	env=${env:-$DEPLOYMENT_ENVIRONMENT}
+	local path=""
+	if [[ -n ${env} ]]; then
+		path="${DEPLOYMENT_ROOT}/${site}/${env}/.site/stemcell"
+	elif  [[ -n ${site} ]]; then
+		path="${DEPLOYMENT_ROOT}/${site}/site/stemcell"
+	else
+		bad_usage_missing "site and/or env, or not in correct directory"
+	fi
+
+	if [[ -f "${path}/alias" ]] ; then # v2 Style
+		local sc_alias="$(cat ${path}/alias)"
+		local name
+		if [[ -f "${path}/os" ]] ; then
+			name="OS:$(cat ${path}/os)"
+		else
+			name="$(cat ${path}/name)"
+		fi
+
+		printf "%s/%s (v2 Manifest alias: %s)\n" "$name" $(cat "${path}/version") "$sc_alias"
+	elif [[ -f "${path}/name" ]] ; then # v1 Style
+		printf "%s/%s\n" $(cat ${path}/name) $(cat ${path}/version)
+	else
+		echo "ERROR: No stemcell found."
+		exit 2
+	fi
+}
+: <<'dox-command:use-stemcell'
+USAGE
+@~include=usage{"args":"[--alias <alias> [--os]] <name> [<version>]"}
+
+DESCRIPTION
+	When inside a site or environment directory, takes the provided stemcell
+	name, and updates the site directory to use that stemcell. You can
+	optionally specify the version of the stemcell to be used as a second
+	argument after the stemcell name.
+
+	For v1 manifests that do not use cloud config, you only specify name and
+	optionally version.
+
+	To generate v2-compatible manifests, you must also specify --alias <alias>
+	and optionally the --os option.
+
+ARGUMENTS
+	name
+		This is the full name of the stemcell, or a shorthand of the name (see the
+		table below).  If the --os option is specified, this name is the name of
+		the os (ie ubuntu-trusty)
+
+	--os
+		This changes the meaning of the name argument, from the name of the stem-
+		cell to the name of the OS.  This can only be used if you also specify the
+		--alias option.
+
+	--alias <alias>
+		Used to specify the stemcell alias as used by v2-style manifests to refer
+		to a stemcell specified in the cloud config on the BOSH Director.
+
+	version
+		The version of the stemcell to be used.  If omitted, it will default to
+		`latest`.  Other valid versions are an explicit numerical version or
+		`track` to indicate the most recent version found in the Genesis Index.
+		Note: you cannot track against OS, only named stemcells.
+
+STEMCELL SHORTHAND NAMES
+	aws:       bosh-aws-xen-hvm-ubuntu-trusty-go_agent
+	azure,
+	hyperv:    bosh-azure-hyperv-ubuntu-trusty-go_agent
+	openstack: bosh-openstack-kvm-ubuntu-trusty-go_agent
+	vcloud:    bosh-vcloud-esxi-ubuntu-trusty-go_agent
+	vsphere:   bosh-vsphere-esxi-ubuntu-trusty-go_agent
+	warden,
+	bosh-lite: bosh-warden-boshlite-ubuntu-trusty-go_agent"
+
+SEE ALSO
+@~include=related{"items":"concept:Stemcells"}
+
+@~scope=common,stemcells
+dox-command:use-stemcell
 cmd_use_stemcell() {
-	local USAGE="use stemcell <name>"
-	local name version
+	local name version sc_alias os
 
 	while (( $# )); do
 		arg=$1 ; shift
 		case ${arg} in
 		(-*)
-			bad_usage ${USAGE}
+			bad_usage_invalid_opt "$arg"
 			;;
 		(*)
 			if [[ -z ${name} ]]; then
@@ -2104,7 +2523,7 @@ cmd_use_stemcell() {
 			elif [[ -z ${version} ]]; then
 				version=${arg}
 			else
-				bad_usage ${USAGE}
+				bad_usage
 			fi
 			;;
 		esac
@@ -2116,26 +2535,15 @@ cmd_use_stemcell() {
 
 	# resolve aliases
 	case ${name} in
-	(aws)
-		name="bosh-aws-xen-hvm-ubuntu-trusty-go_agent"
-		;;
-	(azure|hyperv)
-		name="bosh-azure-hyperv-ubuntu-trusty-go_agent"
-		;;
-	(openstack)
-		name="bosh-openstack-kvm-ubuntu-trusty-go_agent"
-		;;
-	(vcloud)
-		name="bosh-vcloud-esxi-ubuntu-trusty-go_agent"
-		;;
-	(vsphere)
-		name="bosh-vsphere-esxi-ubuntu-trusty-go_agent"
-		;;
-	(warden|bosh-lite)
-		name="bosh-warden-boshlite-ubuntu-trusty-go_agent"
-		;;
+		(aws)              name="bosh-aws-xen-hvm-ubuntu-trusty-go_agent"     ;;
+		(azure|hyperv)     name="bosh-azure-hyperv-ubuntu-trusty-go_agent"    ;;
+		(openstack)        name="bosh-openstack-kvm-ubuntu-trusty-go_agent"   ;;
+		(vcloud)           name="bosh-vcloud-esxi-ubuntu-trusty-go_agent"     ;;
+		(vsphere)          name="bosh-vsphere-esxi-ubuntu-trusty-go_agent"    ;;
+		(warden|bosh-lite) name="bosh-warden-boshlite-ubuntu-trusty-go_agent" ;;
 	esac
 
+	echo "Site ${DEPLOYMENT_SITE} stemcell:"
 	mkdir -p ${DEPLOYMENT_SITE_DIR}/site/stemcell
 	echo "${name}"    > ${DEPLOYMENT_SITE_DIR}/site/stemcell/name
 	echo "${version}" > ${DEPLOYMENT_SITE_DIR}/site/stemcell/version
@@ -2154,161 +2562,82 @@ cmd_use_stemcell() {
 	exit 0
 }
 
-bad_use() {
-	local arg=${1}
-	cat >&2 <<EOF
-USAGE: genesis use release
-       genesis use stemcell
-EOF
-	exit 1
-}
+: <<'dox-command:build'
+USAGE
+@~include=usage{"args":"[<manifest-file>]"}
 
-cmd_stemcells() {
-	local USAGE="stemcells [<site> [<env>]]"
-	local site env
-	while (( $# )); do
-		arg=$1 ; shift
-		case ${arg} in
-		(-*)
-			bad_usage ${USAGE}
-			;;
-		(*)
-			if [[ -z ${site} ]]; then
-				site=${arg}
-			elif [[ -z ${env} ]]; then
-				env=${arg}
-			else
-				bad_usage ${USAGE}
-			fi
-			;;
-		esac
-	done
+DESCRIPTION
+	Compiles all of the YAML templates down to a single BOSH manifest for the
+	current environment.
 
-	setup
-	site=${site:-$DEPLOYMENT_SITE}
-	env=${env:-$DEPLOYMENT_ENVIRONMENT}
+ARGUMENTS
+  manifest-file (optional, default: manifest.yml)
+		The file into which the manifest YAML document is written.
 
-	if [[ -n ${env} ]]; then
-		name=$(cat ${DEPLOYMENT_ROOT}/${site}/${env}/.site/stemcell/name)
-		vers=$(cat ${DEPLOYMENT_ROOT}/${site}/${env}/.site/stemcell/version)
-		printf "%s/%s\n" ${name} ${vers}
-		return
-	fi
-
-	if [[ -n ${site} ]]; then
-		name=$(cat ${DEPLOYMENT_ROOT}/${site}/site/stemcell/name)
-		vers=$(cat ${DEPLOYMENT_ROOT}/${site}/site/stemcell/version)
-		printf "%s/%s\n" ${name} ${vers}
-		return
-	fi
-
-	cat >&2 <<EOF
-USAGE: genesis stemcells <site> [<env>]
-
-(you can also \`cd\` into a site or environment directory
- and just run \`genesis stemcells\` without any arguments)
-EOF
-	exit 1
-}
-
-cmd_releases() {
-	local USAGE="releases [<site> [<env>]]"
-	local site env
-	while (( $# )); do
-		arg=$1 ; shift
-		case ${arg} in
-		(-*)
-			bad_usage ${USAGE}
-			;;
-		(*)
-			if [[ -z ${site} ]]; then
-				site=${arg}
-			elif [[ -z ${env} ]]; then
-				env=${arg}
-			else
-				bad_usage ${USAGE}
-			fi
-			;;
-		esac
-	done
-
-	setup
-	site=${site:-$DEPLOYMENT_SITE}
-	env=${env:-$DEPLOYMENT_ENVIRONMENT}
-
-	if [[ -n ${env} ]]; then
-		for rel in $(releases_for_environment ${site} ${env}); do
-			vers=$(cat ${DEPLOYMENT_ROOT}/${site}/${env}/.global/releases/${rel}/version)
-			printf "%s/%s\n" ${rel} ${vers}
-		done
-		return
-	fi
-
-	if [[ -n ${site} ]]; then
-		for rel in $(releases_for_site ${site}); do
-			vers=$(cat ${DEPLOYMENT_ROOT}/global/releases/${rel}/version)
-			printf "%s/%s\n" ${rel} ${vers}
-		done
-		return
-	fi
-
-	cat >&2 <<EOF
-USAGE: genesis releases <site> [<env>]
-
-(you can also \`cd\` into a site or environment directory
- and just run \`genesis releases\` without any arguments)
-EOF
-	exit 1
-}
-
+@~scope=make
+dox-command:build
 cmd_build() {
-	local USAGE="build [output.yml]"
 	local target
 	while (( $# )); do
 		arg=$1 ; shift
 		case ${arg} in
-		(-*)
-			bad_usage ${USAGE}
-			;;
+		(-*) bad_usage_invalid_opt "$arg"	;;
 		(*)
-			if [[ -z ${target} ]]; then
-				target=${arg}
-			else
-				bad_usage ${USAGE}
-			fi
+			[[ -z ${target} ]] || bad_usage_extra "$arg" "manifest-file" "$target"
+			target=${arg}
 			;;
 		esac
 	done
 	target=${target:-manifest.yml}
-
 	must_be_in_an_environment
-
 	mkdir -p ${DEPLOYMENT_ENV_DIR}/manifests
-
 	build_manifest > ${DEPLOYMENT_ENV_DIR}/manifests/${target}
 	exit 0
 }
 
-cmd_refresh_global() {
-	[[ -z $1 ]] || bad_usage "refresh global"
+: <<'dox-concept:Cached-Definitions'
+DESCRIPTION
+	Stablizes deployment manifests by caching global and site definitions.
 
-	must_be_in_an_environment
-	echo "Refreshing global definitions for ${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}"
-	refresh_global ${DEPLOYMENT_SITE} ${DEPLOYMENT_ENVIRONMENT}
-	exit 0
-}
+	As explained in the Structure concept documents, genesis organizes the parts
+	of the manifest definitions into those that apply globally, site-wide and to
+	a specific environment.  However, since deployments are capable of changing
+	over time (upgrades, bug fixes, expanded functionality), how do you ensure
+	changes propagate correctly
 
-cmd_refresh_site() {
-	[[ -z $1 ]] || bad_usage "refresh site"
+COMMANDS
+@~include=topic{"category":"command","scope":"refresh","desc":"inline","leader":"  <<SCRIPT_NAME>> "}
 
-	must_be_in_an_environment
-	echo "Refreshing site definitions for ${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}"
-	refresh_site ${DEPLOYMENT_SITE} ${DEPLOYMENT_ENVIRONMENT}
-	exit 0
-}
+SEE ALSO
+@~include=related{"items":["concept:Structure","concept:Makefiles","concept:CI"]}
+@~scope=makefile
+dox-concept:Cached-Definitions
 
+: <<'dox-partial:refresh'
+USAGE
+@~include=usage{"args":"[(global|site|all|makefile|readme)]"}
+
+DESCRIPTION
+	Refresh the cached copies of site and/or global definitions inside the current
+	environment directory.  Can also be used to recreate the Makefile and readme
+	files after a Genesis upgrade.  If run without a subcommand, it will default
+	to 'all'.
+dox-partial:refresh
+
+: <<'dox-command:refresh-all'
+USAGE
+@~include=usage{"cmd":"refresh [all]"}
+
+DESCRIPTION
+	Refresh (or create) the cached copies of site and global definitions inside
+	the current environment directory.  This is the default action if no refresh
+	subcommand is specified.
+
+@~group=refresh
+@~scope=make
+dox-command:refresh-all
 cmd_refresh_all() {
-	[[ -z $1 ]] || bad_usage "refresh all"
+	[[ -z $1 ]] || bad_usage_no_args
 
 	must_be_in_an_environment
 	echo "Refreshing site definitions for ${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}"
@@ -2318,16 +2647,79 @@ cmd_refresh_all() {
 	exit 0
 }
 
+: <<'dox-command:refresh-global'
+USAGE
+@~include=usage
+
+DESCRIPTION
+	Create or refresh the files in the .global cached directory in the current
+	environment directory from the files in the ../../global directory.
+
+@~group=refresh
+@~scope=make
+dox-command:refresh-global
+cmd_refresh_global() {
+	[[ -z $1 ]] || bad_usage_no_args
+
+	must_be_in_an_environment
+	echo "Refreshing global definitions for ${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}"
+	refresh_global ${DEPLOYMENT_SITE} ${DEPLOYMENT_ENVIRONMENT}
+	exit 0
+}
+
+: <<'dox-command:refresh-site'
+USAGE
+@~include=usage
+
+DESCRIPTION
+	Create or refresh the files in the .site cached directory in the current
+	environment directory from the files in the ../site directory.
+
+@~group=refresh
+@~scope=make
+dox-command:refresh-site
+cmd_refresh_site() {
+	[[ -z $1 ]] || bad_usage_no_args
+
+	must_be_in_an_environment
+	echo "Refreshing site definitions for ${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}"
+	refresh_site ${DEPLOYMENT_SITE} ${DEPLOYMENT_ENVIRONMENT}
+	exit 0
+}
+
+: <<'dox-command:refresh-makefile'
+USAGE
+@~include=usage
+
+DESCRIPTION
+	Rebuild the Makefile for an environment, which can be useful to bring old
+	deployments in-line with newer versions of Genesis.
+
+@~group=refresh
+@~scope=makefile
+dox-command:refresh-makefile
 cmd_refresh_makefile() {
-	[[ -z $1 ]] || bad_usage "refresh makefiles"
+	[[ -z $1 ]] || bad_usage_no_args
 
 	must_be_in_an_environment
 	echo "Refreshing Makefile for ${DEPLOYMENT_SITE}/${DEPLOYMENT_ENVIRONMENT}"
 	create_makefile "${DEPLOYMENT_ENV_DIR}/Makefile"
 }
 
+: <<'dox-command:refresh-readmes'
+USAGE
+@~include=usage
+
+DESCRIPTION
+	Rebuild the various README files for the top-level and 'global' directories,
+	and all sites and environments, which can be useful to bring old deployments
+	in-line with newer versions of Genesis.
+
+@~group=refresh
+@~scope=make
+dox-command:refresh-readmes
 cmd_refresh_readmes() {
-	[[ -z $1 ]] || bad_usage "refresh readmes"
+	[[ -z $1 ]] || bad_usage_no_args
 
 	setup
 	echo "Refreshing README for the whole repository"
@@ -2346,26 +2738,20 @@ cmd_refresh_readmes() {
 	done
 }
 
-bad_refresh() {
-	local arg=${1}
-	cat >&2 <<EOF
-USAGE: genesis refresh (all|global|site|makefile|readme)
+: <<'dox-command:deploy'
+USAGE
+@~include=usage
 
-Refreshes the global and/or site definitions inside of a single environment,
-by copying in the definitions from upstream.
+DESCRIPTION
+	When run from inside of an environment directory, builds and deploys your
+	BOSH manifest. A redacted copy is left in the repo for posterity. The copy
+	deployed is non-redacted.
 
-The argument 'makefile' only rebuilds the Makefile for an environment,
-which can be useful to bring old deployments in-line with newer versions
-of Genesis.
-
-Similarly, 'readme' only recreates the various README files for the top-level,
-the global/ directories, and all sites and environments.
-EOF
-	exit 1
-}
-
+@~group=build
+@~scope=make
+dox-command:deploy
 cmd_deploy() {
-	[[ -z $1 ]] || bad_usage "deploy"
+	[[ -z $1 ]] || bad_usage_no_args
 
 	must_be_in_an_environment
 	preflight_deployment
@@ -2405,18 +2791,7 @@ cmd_deploy() {
 	esac
 }
 
-cmd_embed() {
-	[[ -z $1 ]] || bad_usage "embed"
-
-	echo "Embedding genesis script into repository"
-	setup
-
-	mkdir -p ${DEPLOYMENT_ROOT}/bin
-	cp ${BASH_SOURCE[0]} ${DEPLOYMENT_ROOT}/bin/genesis
-	chmod 755 ${DEPLOYMENT_ROOT}/bin/genesis
-
-	${DEPLOYMENT_ROOT}/bin/genesis version
-}
+### CI SUPPORT FUNCTIONS
 
 ci_smoke_test() {
 	local smoke_test=$(spruce json $(ci_pipeline_yaml) | jq -r '.smoke_test')
@@ -3759,6 +4134,44 @@ EOF
 	exit 1
 }
 
+: <<'dox-command:bosh'
+USAGE
+	<<SCRIPT_NAME>> bosh <args...>
+
+DESCRIPTION
+	Run a bosh command against a freshly generated non-redacted BOSH manifest
+	from the current environment directory.
+
+	For configurations that don't make use of Vault, this is equivalent of
+	building the manifest and adding '-d manifests/manifests.yml' to the BOSH
+	command.  When vault operators are present in the source yml files, this is
+	the only way run BOSH command using a manifest since the one built in the
+	manifests directory will have all vault values redacted.
+
+	Similarly, it provides an alternative method for running `make deploy` with
+	further arguments, such as --recreate.
+
+	All BOSH commands are available, but may not necessarily benefit from the
+	manifest re-generation step.
+
+ARGUMENTS
+	The arguments expected for this command are exactly what you'd specify for a
+	normal bosh CLI command, less the -d option which this adds for you.  See
+	`bosh help <command>` for help on the desired bosh command.
+
+EXAMPLES
+  Rebuild the worker/1 job:
+  $ genesis bosh -t prod recreate worker 1
+
+  SSH into etcd/0 instance
+  $ genesis bosh ssh etcd/0
+
+  Dry-run of a deploy while showing all changes:
+  $ genesis bosh deploy --dry-run --no-redact
+
+SEE ALSO
+@~include=related{"items":["concept:Makefiles","concept:Vault-Secrets"]}
+dox-command:bosh
 cmd_bosh() {
 	# NOTE: cmd_bosh specifically avoids argv inspection
 	must_be_in_an_environment
@@ -3793,23 +4206,6 @@ cmd_dump() {
 	exit 0
 }
 
-bad_command() {
-	local cmd=${1}
-	cat >&2 <<EOF
-Unrecognized sub-command: '$cmd'
-
-Try one of these:
-
-   genesis help
-   genesis new (deployment|site|environment)
-   genesis build
-   genesis refresh (global|site|all|makefile|readme)
-   genesis bosh ...
-
-EOF
-	exit 1
-}
-
 checksum() {
 	if [[ -z $(command -v sha1sum) ]]; then
 		shasum "$@"
@@ -3818,197 +4214,528 @@ checksum() {
 	fi
 }
 
-####################################################
-# multi-call interface
+: <<'dox-command:help'
+NAME
+	help - Display help on genesis concepts and commands
 
-main() {
-	local cmd=${1:-help} ; shift
+USAGE
+@~include=usage{"args":[" ","--topics","--<category>","[--<category>] <topic>"]}
 
-	case ${cmd} in
-	(ping)
+DESCRIPTION
+	Get help on how to use `genesis`.
+
+	With no arguments, will print this help message.  By specifying a category,
+	the list of topics in that category will be specified.  The available
+	categories are:
+@~include=categories{"leader":"    * "}
+
+  You can also specify --topics to get a list of all topics in all categories.
+
+	For detailed help on a given topic, you can specify that topic as an argument
+	to the help command.  For topics that are composed of multiple words, do
+	*not* wrap the topic in quotes.  In the rare case that the topic appears in
+	multiple categories, you can specify the category type as an double-hyphenated
+	option.
+dox-command:help
+
+cmd_help() {
+	local category=""
+	local topic=""
+	while (( $# )); do
+		arg="$1"; shift
+		case "${arg}" in
+		(*-) bad_usage_no_opts ;;
+		(--*) [[ -z "$category" ]] && category="${arg:2}" || bad_usage "Can only specify one category" ;;
+		(*)  topic="${topic:+"${topic}-"}${arg}" ;;
+		esac
+	done
+
+	local result=$(__dox_get_help "$category" "$topic")
+	if [[ $? -ne 0 ]] ; then
+		echo >&2 "ERROR: Could not fetch help - fatal internal error"
+		exit 1
+	fi
+
+	local pager="cat"
+	# TODO: The following pages if output is bigger than the current screen - is
+	#				this a good idea?
+	#local rows="$(stty -a | head -1 | tr ';' "\n" | grep rows | sed -e 's/^[^0-9]*\([0-9]\{1,\}\).*$/\1/')"
+	#[[ "$rows" -gt 1 && "$(echo "$result" | wc -l)" -ge "$rows" ]] && pager="less"
+	echo "$result"$'\n' | $pager
+}
+
+bad_usage() {
+  local msg="${1:-bad usage}" callee=${2:-${FUNCNAME[1]}}
+
+  local callee_bits=( ${callee//_/ } )
+  local category="${callee_bits[0]}"
+  local name=( "${callee_bits[@]:1}" )
+  local cmd=$(IFS='-'; echo "${name[*]}")
+
+  [[ "$category" == "cmd" ]] && category="command"
+  local content="$(__dox_get_usage "$cmd" "$category")"
+  local prefix="[$SCRIPT_NAME${name:+ ${name[@]}}] "
+  echo >&2 $'\n'"$(__dox_reflow_text "ERROR: ${msg}" "${prefix//?/ }" "$prefix")"
+  echo >&2 "$(__dox_process_content "USAGE"$'\n'"${content}")"
+  echo >&2 $'\n'"For more details, run \`$0 help <command>\` for the desired command."$'\n'
+  exit 1
+}
+bad_usage_invalid_opt() { bad_usage "invalid option '$1'"; }
+bad_usage_no_args()     { bad_usage "does not take any options or arguments"; }
+bad_usage_no_opts()     { bad_usage "does not take any options"; }
+bad_usage_missing()     { bad_usage "required argument for $1 not provided"; }
+bad_usage_extra()       { bad_usage "extraneous argument '${1}'${2:+"; $2 already provided as '$3'"}"; }
+
+bad_usage_partial() {
+	local cmd="$1" subcmd="$2"
+	if [[ -n "$subcmd" ]] ; then
+		bad_usage "invalid subcommand '${subcmd}'${cmd:+" for command '${cmd}'"}" "partial_${cmd}"
+	else
+		bad_usage "missing subcommand for '${cmd}' command" "partial_${cmd}"
+	fi
+}
+
+check_opt_usage() {
+	if [[ -z "$2" || "${2:0:1}" != '-' ]] ; then
+		bad_usage "missing value for option $1" "${FUNCNAME[1]}"
+	fi
+}
+
+__dox_get_help() {
+  local category="$1" topic="$2"
+	[[ -z "${topic}" && -z "${category}" ]] && { category="command"; topic="help"; }
+	if [[ -z "${topic}" ]] ; then
+		[[ "$category" == 'topics' ]] && { category='' ; } # --topics is a meta-topic of all topics
+		IFS=$'\n' read -rd '' -a categories <<< "$(__dox_get_topics '' "$category" | sed 's/:.*//' | sort | uniq )"
+		echo ""
+		if [[ "${#categories[@]}" -eq 0 ]] ; then
+			echo >&2 $'\n'"[$SCRIPT_NAME help] ERROR: No help category matching '$category'"
+			echo >&2 $'\n''For information on available help topics, run `'"$0"' help --topics`'
+			exit 2
+		fi
+		for category in "${categories[@]}" ; do
+			[[ "${category}" == "partial" ]] && continue
+			local _header="Available '${category}' help topics:"
+			echo "${_header}"$'\n'"${_header//?/-}"
+			__dox_generate_topic_includes '{"category":"'$category'","desc":"inline","leader":"  * "}'
+			echo ""
+		done
 		exit 0
-		;;
-	(version)
-		cmd_version $*
-		;;
-	(update)
-		cmd_update $*
-		;;
-	(help)
-		cmd_help $*
-		;;
-	(new)
-		local arg=${1:-} ; shift
-		case ${arg} in
-		(deployment)
-			cmd_new_deployment $*
-			;;
-		(site)
-			cmd_new_site $*
-			;;
-		(env|environment)
-			cmd_new_environment $*
-			;;
-		(*)
-			bad_new ${arg}
-			;;
+	fi
+
+	local topic_list=( $(__dox_get_topics "$topic" "$category" ) )
+	if [[ "${#topic_list[@]}" -eq 0 ]] ; then
+		# Check for aliases
+		if grep '^@~alias=\(.*,\)\{0,\}'"$topic"'\(,.*\)\{0,\}' $0 >/dev/null 2>&1; then
+			topic_list=( $(__dox_get_topics '' "$category" '' "$topic" ) )
+		fi
+	fi
+	if [[ ${#topic_list[@]} -eq 1 ]] ; then
+		# Only one potential match
+		IFS=':' read category topic <<< "${topic_list[0]}"
+	elif [[ ${#topic_list[@]} -eq 0 ]] ; then
+		__dox_not_found
+	else
+		local exact_match
+		exact_match=( $(printf -- '%s\n' "${topic_list[@]}" | grep ':'"$topic"'$') )
+		if [[ ${#exact_match[@]} -eq 1 ]] ; then
+			IFS=':' read category topic <<< "${exact_match[0]}"
+		else
+			__dox_ambiguous_topic "$topic" "${topic_list[@]}"
+			return 2
+		fi
+	fi
+
+	if [[ "$category" == 'partial' ]] ; then
+		__dox_ambiguous_topic "$topic"
+		return 0
+	else
+		category="${category:-command}"
+		local content="$(__dox_get_content "${topic}" "${category}")"
+		__dox_process_content "$content"
+	fi
+	return 0
+}
+__dox_get_content() {
+	#echo >&2 "======"$'\n'"DEBUG: called '${FUNCNAME[0]}' with "$'\n'" --($@)--"$'\n'"^^^^^^"
+	local topic="$1" category="${2:-'command'}"
+	local pattern="$(echo "dox-${category}:${topic}" | tr " " "-")"
+	# Check if content is present
+	if grep "^: <<'$pattern'\$" $0 >/dev/null 2>&1 && grep "^$pattern\$" $0 >/dev/null 2>&1; then
+		# FIXME: changing all tabs to 2 spaces; ideally this should only change leading tabs
+		local content="$(sed \
+			-e 's/	/  /g;'"/^: <<'$pattern'/,/^$pattern\$/"'!d;//d' \
+			-e "s:<<[S]CRIPT_NAME>>:$SCRIPT_NAME:g" \
+			$0 )"
+
+		# Process usage includes
+		declare -a uses
+		IFS=$'\n'	read -rd '' -a uses <<< "$(__dox_get_meta "$content" 'include' 'usage')"
+		local _line
+		for _line in "${uses[@]}" ; do
+			local opts="${_line:5}"
+			local usage="$(__dox_generate_usage "$topic" "${opts:-"{}"}" )"
+			content="$( __dox_replace_line "$content" "@~include=${_line}" "$usage" )"
+		done
+		echo "$content"
+	fi
+}
+
+__dox_get_usage() {
+	local topic="$1" category="${2:-'command'}"
+	local content="${3:-"$(__dox_get_content "$topic" "$category")"}"
+	local usage="$(__dox_parse_section "$content" 'USAGE')"
+	if [[ -z "$usage" && "$category" == "partial" ]] ; then
+		usage='@~include=topic{"category":"command","desc":"usage","leader":"  ","partial":"'"${topic}"'"}'
+	fi
+	echo "$usage" | grep -v '^@~alias'
+
+}
+
+__dox_process_content() {
+	local _tail=$'\n'" "
+	local content="$1${_tail}"
+
+	# Process meta details
+	declare -a includes
+	IFS=$'\n' read -rd '' -a includes <<< "$(__dox_get_meta "$content" include)"
+	local _tag
+	for _tag in "${includes[@]}"; do
+		local replacement=""
+		case "${_tag%\{*}" in
+			(topic)      replacement="$(__dox_generate_topic_includes "${_tag:5}")" ;;
+			(categories) replacement="$(__dox_generate_category_list "${_tag:10}")" ;;
+      (related)    replacement="$(__dox_generate_related_list "${_tag:7}")" ;;
+			(*)          replacement='' ;;
 		esac
-		;;
-	(add)
-		local arg=${1:-} ; shift
-		case ${arg} in
-		(release)
-			cmd_add_release $*
+		content="$( __dox_replace_line "$content" "@~include=${_tag}" "$replacement" )"
+	done
+	echo $'\n'"$( __dox_trim "${content}")"$'\n'
+}
+
+__dox_replace_line() {
+	# Args: content, line, replacement
+	while IFS= read -r line; do
+		if [[ "$line" == "$2" ]] ; then
+#			[[ -z "$3" ]] && continue
+			line="$3"
+		fi
+		echo "$line"
+	done <<< "$1"
+}
+
+__dox_not_found() {
+	echo >&2 $'\n'"[$SCRIPT_NAME help] ERROR: No help topic matching '${argv[@]:1}'"
+	echo >&2 $'\n''For information on available help topics, run `'"$0"' help --topics`'
+	exit 2
+}
+
+__dox_ambiguous_topic() {
+	local topic=$1 ; shift
+	local _args=( "$@" )
+	local content="$(__dox_get_content $topic 'partial')"
+
+	# We only use the description and usage from partials
+	local _usage="$(__dox_get_usage $topic 'partial' "$content")"
+	local _desc="$(__dox_parse_section "$content" DESCRIPTION)"
+	[[ -n "$_desc" ]] || { _desc="  This is a partial command stub which requires further arguments." ; }
+
+	content="$(cat<<EOF
+USAGE
+$_usage
+
+DESCRIPTION
+$_desc
+
+@~include=topic{"category":"concept","desc":"block","leader":"  ","partial":"${topic}"}
+
+COMMANDS
+@~include=topic{"category":"command","desc":"inline","leader":"  ","partial":"${topic}"}
+
+  For more details, run \`$SCRIPT_NAME help <command>\` for the desired command.
+EOF)"
+
+	__dox_process_content "$content"
+}
+
+__dox_get_meta() {
+	local content="$1" key=${2:-'.*'} sep="=${3:+"${3}\\b"}" filter=${2:+"$2="}
+	echo "$content" | grep '^@~'"$key$sep" | sed 's/^@~'"$filter"'//'
+}
+
+__dox_get_meta_option() {
+	local meta_str="$1" option="$2"
+	opt_line="$(echo "$meta_str" | sed 's/^[^{]*\(.*\)[^}]*$/\1/')"
+	case "$(echo "$opt_line" | jq -r ".$option | type")" in
+		(array)
+			i=0; while value="$(echo "$opt_line" | jq -er ".${option}[${i}]")" ; do
+				echo $value
+				((i++))
+			done
 			;;
-		(*)
-			bad_add ${arg}
-			;;
-		esac
-		;;
-	(set)
-		local arg=${1:-} ; shift
-		case ${arg} in
-		(release)
-			cmd_set_release $*
-			;;
-		(*)
-			bad_set ${arg}
-			;;
-		esac
-		;;
-	(use)
-		local arg=${1:-} ; shift
-		case ${arg} in
-		(release)
-			cmd_use_release $*
-			;;
-		(stemcell)
-			cmd_use_stemcell $*
-			;;
-		(*)
-			bad_use ${arg}
-			;;
-		esac
-		;;
-	(stemcell|stemcells)
-		cmd_stemcells $*
-		;;
-	(release|releases)
-		cmd_releases $*
-		;;
-	(build)
-		REDACT=y cmd_build $*
-		;;
-	(refresh)
-		local arg=${1:-all} ; shift
-		case ${arg} in
-		(global)
-			cmd_refresh_global $*
-			;;
-		(site)
-			cmd_refresh_site $*
-			;;
-		(all)
-			cmd_refresh_all $*
-			;;
-		(makefile|makefiles)
-			cmd_refresh_makefile $*
-			;;
-		(readme|readmes)
-			cmd_refresh_readmes $*
-			;;
-		(*)
-			bad_refresh ${arg}
-			;;
-		esac
-		;;
-	(deploy)
-		cmd_deploy
-		;;
-	(embed)
-		cmd_embed
-		;;
-	(ci)
-		TERM=dumb
-		command=""
-		CI_PIPELINE=${CI_PIPELINE:-}
-		while [[ $# -ne 0 ]]; do
-			local arg=${1:-} ; shift
-			case ${arg} in
-			(-p|--pipeline)
-				shift ; CI_PIPELINE=${2:-} ; shift
+		(null) return 1;;
+		(*)    echo "$opt_line" | jq  -er ".$option" ;;
+	esac
+}
+
+__dox_get_sections() {
+	echo "$1" | grep '^[A-Z][-A-Z0-1 ]*'
+}
+
+__dox_parse_section() {
+	local content="$1" subject="$2"
+	local output
+	if [[ -n "$subject" ]] ; then
+		_found=false
+		_nl=""
+		while IFS= read -r line; do
+			[[ "${line}" =~ ^${subject} ]] && { _found=true ; continue ; }
+			[[ ${_found} == true ]]  || { continue ; }
+			[[ "${line}" =~ ^[^[:space:]@] ]] && { break ; }
+			[[ "${line}" =~ ^$ ]] && { _nl="${_nl}"$'\n' ; continue ; }
+			echo "${_nl}${line}" ; _nl=""
+		done <<< "$content"
+	fi
+}
+
+__dox_get_topics() {
+	#echo >&2 "======"$'\n'"DEBUG: called '${FUNCNAME[0]}' with "$'\n'" --($@)--"$'\n'"^^^^^^"
+	local topic="${1:-.*}" category="${2:-.*}" scope="$3" alias="$4"
+	local candidates=( $(grep '^: <<'"'dox-${category}:${topic}\(-.*\)\?'\$" $0 | sed 's/.*'".dox-//;s/.\$//") )
+	for candidate in "${candidates[@]}" ; do
+		if [[ -n $scope ]] ; then
+			IFS=':' read category topic <<< "$candidate"
+			if __dox_get_content $topic $category | grep '@~scope=\(.*,\)\{0,\}'"$scope"'\(,.*\)\{0,\}' 2>&1 > /dev/null ; then
+				echo $candidate
+			fi
+		elif [[ -n $alias ]] ; then
+			IFS=':' read category topic <<< "$candidate"
+			if __dox_get_content $topic $category | grep '@~alias=\(.*,\)\{0,\}'"$alias"'\(,.*\)\{0,\}' 2>&1 > /dev/null ; then
+				echo $candidate
+			fi
+		else
+			echo $candidate
+		fi
+	done
+}
+
+__dox_generate_topic_includes() {
+	local opts="$1"
+	local scope="$(__dox_get_meta_option "${opts}" scope)"
+	local category="$(__dox_get_meta_option "${opts}" category)"
+	local partial="$(__dox_get_meta_option "${opts}" partial)"
+	local leader="$(__dox_get_meta_option "${opts}" leader)"
+	local desc="$(__dox_get_meta_option "${opts}" desc)"
+	local items=( $(__dox_get_topics "$partial" "$category" "$scope") )
+
+	local item
+	if [[ "${desc}" == "inline" ]] ; then
+		local indent=0
+		for item in "${items[@]}" ; do
+			local _header="${leader}${item#*:}: "
+			[[ "${indent}" -ge "${#_header}" ]] || { indent="${#_header}" ; }
+		done
+		local padding="$(seq -f ' ' -s '' $indent)"
+	fi
+
+	for item in "${items[@]}" ; do
+		local _header="${leader}""$(echo "${item#*:}" | sed -e 's/-/ /g')"":"
+		case "${desc}" in
+			(inline)
+				local _desc
+				_desc="$( __dox_parse_section "$(__dox_get_content "${item#*:}" "${item%%:*}" )"  DESCRIPTION )"
+				__dox_reflow_text "${_desc%%$'\n'$'\n'*}" "$padding" "${_header}${padding:${#_header}}"
+				echo ""
 				;;
-			(-*)
-				echo >&2 "bad flag '${arg}'"
-				exit 1
+			(block)
+				echo "${_header}"
+				local _desc
+				_desc="$( __dox_parse_section "$(__dox_get_content "${item#*:}" "${item%%:*}" )"  DESCRIPTION )"
+				__dox_reflow_text "${_desc%%$'\n'$'\n'*}" "${leader}  "
+				echo ""
+				;;
+			(usage)
+				_desc="$( __dox_parse_section "$( __dox_get_content "${item#*:}" "${item%%:*}" )" USAGE | grep -v '^@~')"
+				while read -r line ; do echo "${leader}${line}" ; done <<< "$_desc"
 				;;
 			(*)
-				if [[ -n ${command} ]]; then
-					echo >&2 "bad command '${command}'"
-					exit 1
-				fi
-				command=$arg
+				echo "${_header/%:/}"
 				;;
-			esac
-		done
-
-		case ${command} in
-		(alpha)
-			cmd_ci_alpha $*
-			;;
-		(beta)
-			cmd_ci_beta $*
-			;;
-		(parent)
-			cmd_ci_parent $*
-			;;
-		(auto)
-			cmd_ci_auto $*
-			;;
-		(smoke-test)
-			cmd_ci_smoke_test $*
-			;;
-		(manual)
-			cmd_ci_manual $*
-			;;
-		(repipe)
-			cmd_ci_repipe $*
-			;;
-		(flow)
-			cmd_ci_flow $*
-			;;
-		(stemcells)
-			cmd_ci_stemcells $*
-			;;
-		(stage1)
-			cmd_ci_stage1 $*
-			;;
-		(stage2)
-			cmd_ci_stage2 $*
-			;;
-		(stage-smoke-test)
-			cmd_ci_stage_smoke_test $*
-			;;
-		(draft-message)
-			cmd_ci_draft_message $*
-			;;
-		(check)
-			cmd_ci_check
-			;;
-		(*)
-			bad_ci ${arg}
-			;;
 		esac
-		;;
-	(dump)
-		cmd_dump
-		;;
-	(bosh)
-		cmd_bosh $*
-		;;
-	(*)
-		bad_command ${cmd}
-		;;
+	done
+}
+
+__dox_generate_category_list() {
+	local opts="$1"
+	local leader="$( __dox_get_meta_option "${opts}" "leader" )"
+	local items=("commands" "concepts") # hardcoded for now
+	for category in "${items[@]}" ; do
+		echo "${leader}${category}"
+	done
+}
+
+__dox_generate_related_list() {
+	local opts="$1"
+	local desc=''
+	local category
+  declare -a items
+	IFS=$'\n' items=( $( __dox_get_meta_option "${opts}" "items" ) )
+	unset IFS
+	for topic in "${items[@]}" ; do
+		category="${topic%%:*}"
+		if [[ "$category" == "$topic" ]] ; then
+			category=""
+		else
+			topic="${topic#*:}"
+		fi
+		_desc="$( __dox_parse_section "$(__dox_get_content "$topic" "$category")" DESCRIPTION "" )"
+		[[ -n "$_desc" ]] || continue
+		echo "  $topic${category:+" ($category)"}:"
+		__dox_reflow_text "${_desc%%$'\n'$'\n'*}" "    "
+		echo ""
+	done
+}
+
+__dox_generate_usage() {
+	local topic="$1"
+	local opts="$2"
+	local args
+	local leader="$(__dox_get_meta_option "${opts}" "leader" )"
+	local cmd="$(__dox_get_meta_option "${opts}" "cmd" )"
+
+	#FIXME: this doesn't allow empty strings as a valid arg, necessitating using ' ' for no args
+	IFS=$'\n' args=( $(__dox_get_meta_option "${opts}" "args" ) )
+	unset IFS
+	leader="${leader:-"  "}"
+	cmd="${cmd:-"$(echo "$topic" | tr "-" " ")"}"
+
+	[[ ${#args[@]} -gt 0 ]] || args+='' # default with no arguments
+	local arg_set
+	for arg_set in "${args[@]}" ; do
+		echo "${leader}${0} ${cmd} ${arg_set}"
+	done
+}
+
+__dox_reflow_text() {
+	local content="$(echo ${1} | expand -t 2)"
+	local leader="$2"
+	local header="$3"
+	local width=$(( 79 - ${#leader} ))
+	unset IFS
+	while read -r line ; do
+		echo "${header:-$leader}${line}"
+		header=""
+	done <<< "$(set +x; echo ${content} | fold -s -w $width)"
+}
+__dox_trim() {
+	# trims unused meta, whitespace off end and collapse inner multiple blank lines
+	content="$( echo "$1" | grep -v '^@~.*')"
+	i=${#content}
+	while (( i-- )) ; do [[ "${content:$i:1}" =~ ^[[:space:]]$ ]] || { break ; } ; done
+	echo "${content:0:$(( ++i ))}" | cat -s
+}
+
+
+####################################################
+# multi-call interace
+
+main() {
+	unset IFS
+	local cmd=${1:-info} ; shift
+	case ${cmd} in
+		(ping)                   exit 0 ;;
+		(version)                cmd_version $* ;;
+		(help)                   cmd_help $* ;;
+		(info)                   cmd_help --overview genesis ;;
+		(update)                 cmd_update $* ;;
+		(new)
+			local arg=${1:-} ; shift
+			case ${arg} in
+				(deployment)         cmd_new_deployment $* ;;
+				(site)               cmd_new_site $* ;;
+				(env|environment)    cmd_new_environment $* ;;
+				(*)                  bad_usage_partial "${cmd}" ${arg} ;;
+			esac
+			;;
+		(stemcell|stemcells)     cmd_stemcells $* ;;
+		(release|releases)       cmd_releases $* ;;
+		(add)
+			local arg=${1:-} ; shift
+			case ${arg} in
+				(release)            cmd_add_release $* ;;
+				(*)                  bad_usage_partial "${cmd}" ${arg} ;;
+			esac
+			;;
+		(set)
+			local arg=${1:-} ; shift
+			case ${arg} in
+				(release)            cmd_set_release $* ;;
+				(*)                  bad_usage_partial "${cmd}" ${arg} ;;
+			esac
+			;;
+		(use)
+			local arg=${1:-} ; shift
+			case ${arg} in
+			(release)              cmd_use_release $* ;;
+			(stemcell)             cmd_use_stemcell $* ;;
+			(*)                    bad_usage_partial "${cmd}" ${arg} ;;
+			esac
+			;;
+		(refresh)
+			local arg=${1:-all} ; shift
+			case ${arg} in
+				(global)             cmd_refresh_global $* ;;
+				(site)               cmd_refresh_site $* ;;
+				(all)                cmd_refresh_all $* ;;
+				(makefile|makefiles) cmd_refresh_makefile $* ;;
+				(readme|readmes)     cmd_refresh_readmes $* ;;
+				(*)                  bad_usage_partial "${cmd}" ${arg} ;;
+			esac
+			;;
+		(build)                  REDACT=y cmd_build $* ;;
+		(deploy)                 cmd_deploy ;;
+		(embed)                  cmd_embed ;;
+		(ci)
+			TERM=dumb
+			# Buildout command before parsing opts and args
+			local ci_cmd=""
+			local ci_partial=""
+			while [[ $# -gt 0 && -z "$ci_cmd" ]] ; do
+				potential="${potential:+"$potential "}$1"
+				case "$potential" in
+					(alpha|beta|auto|manual|repipe|flow|smoke-test)   ci_cmd="$potential" ;;
+					(parent|"draft-messages"|stemcells)    ci_cmd="$potential" ;;
+					("stage1"|"stage2"|"stage-smoke-test") ci_cmd="$potential" ;;
+					(*)
+						# In future, partials may be valid commands (ie stage 1 and stage 1
+						# smoke test) so if we have a partial that can also be a command,
+						# check here before delaring bad usage. (also why we don't shift
+						# until after we test)
+						bad_usage_partial "ci${ci_partial:+ $ci_partial}" "$1"
+						;;
+				esac
+				shift
+			done
+			[[ -n $ci_cmd ]] || bad_usage_partial "ci${ci_partial:+ $ci_partial}" ""
+
+			# Check for common pipeline arg
+			declare -a ci_args
+			CI_PIPELINE=${CI_PIPELINE:-}
+			while [[ $# -gt 0 ]]; do
+				local arg=${1:-} ; shift
+				case ${arg} in
+					(-p|--pipeline) CI_PIPELINE="${1:-}"; shift ;;
+					(*)             ci_args+=("$arg") ;;
+				esac
+			done
+			set -- "${ci_args[@]}"
+
+			# Process sub-commands
+			$(echo "cmd_ci_${ci_cmd}" | tr "-" "_") $*
+			;;
+		(dump)                   cmd_dump ;;
+		(bosh)                   cmd_bosh $* ;;
+		(*)                      bad_usage_partial "" "$cmd" ;;
 	esac
 }
 


### PR DESCRIPTION
This is the first PR in a series that was split from PR #112 

It adds the __dox_* help system for unified embedded help (similar to perl POD).  It also includes
code changes to various bash functions that modify the argument parsing and error handling based on usage.  There were further non-functional changes to compress some code to reduce overall line count.