### PR TITLE
update bash syntax to correctly use the var

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -214,7 +214,7 @@ setup() {
 		while IFS='' read -r line || [[ -n "$line" ]]; do
 			cmd=$(echo $line | perl -pe 's|^(.*?):.*$|$1|')
 			ver=$(echo $line | perl -pe 's|^.*?: *(.*)$|$1|')
-			
+
 			if [[ ${cmd} == "genesis" ]] ; then
 				cmd_version="${VERSION}"
 			else
@@ -4435,7 +4435,7 @@ cmd_ci_stemcells() {
 		exit 2
 	fi
 
-	REPO_IN=$(cd $(dirname $BASH_SOURCE[0])/..; pwd)
+	REPO_IN=$(cd $(dirname ${BASH_SOURCE[0]})/..; pwd)
 	for dir in ${STEMCELLS}/*; do
 		local name=${dir##*/}
 		local vers=$(cat ${dir}/version)


### PR DESCRIPTION
Docker images were failing without this