### PR TITLE
Added -L|--link-dev-kit option to genesis init

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -212,6 +212,14 @@ sub chdir_or_fail {
 	chdir $dir or die "Unable to change directory to $dir/: $!\n";
 }
 
+# symlink_or_fail $source $dest;
+sub symlink_or_fail {
+	my ($source, $dest) = @_;
+	-d $source or die "$source does not exist!\n";
+	-e $dest and die abs_path($dest)." already exists!";
+	symlink($source, $dest) or die "Unable to link $source to $dest: $!\n";
+}
+
 our @DIRSTACK;
 sub pushd {
 	my ($dir) = @_;
@@ -3349,41 +3357,56 @@ USAGE: genesis init [-k KIT/VERSION] [-d directory] [name]
 
 OPTIONS
 $GLOBAL_USAGE
-  -k, --kit        Name (and optionally, version) of the Genesis Kit to
-                   base these deployments on.  I.e.: shield/6.3.0.  If you do
-                   not specify a kit, a dev directory will be created for you
-                   to develop a local kit into.
-  -d, --directory  By default, the directory in which the Genesis deployment
-                   will be created in will be named ./<name>-deployments.  Use
-                   this option to change it to something else.
+  -k, --kit           Name (and optionally, version) of the Genesis Kit to base
+                      these deployments on.  I.e.: shield/6.3.0.  If you do not
+                      specify a kit, a dev directory will be created for you to
+                      develop a local kit into.
+  -L, --link-dev-kit  Instead of using a kit or initializing an empty dev
+                      directory, this will link the specified directory to the
+                      dev directory.
+  -d, --directory     By default, the directory in which the Genesis deployment
+                      will be created in will be named ./<name>-deployments.
+                      Use this option to change it to something else.
 
-  name             If the name argument is not specified, it will default to
-                   the same name as the kit.  You must specify either name or
-                   kit.
+  name                If the name argument is not specified, it will default to
+                      the same name as the kit.  You must specify either name
+                      or kit.
 EOF
 sub {
 	my %options;
 	options(\@_, \%options, qw/
 		kit|k=s
 		directory|d=s
+		link-dev-kit|L=s
 	/);
 	usage(1) if @_ > 1; # name is now optional if kit specified
 	check_prereqs(no_repo_needed => 1);
 
+	my $abs_target;
+	if ($options{'link-dev-kit'}) {
+		usage(1,"Cannot specify both a kit (-k) and a link to a kit (-L)") if $options{kit};
+		$abs_target = abs_path($options{'link-dev-kit'});
+		my $pwd = Cwd::getcwd();
+		die "Link target '$options{'link-dev-kit'}' cannot be found from $pwd!\n" unless $abs_target;
+	}
+
 	my ($name) = @_;
 	unless ($name) {
-		unless ($options{kit}) {
-			printf STDERR "You must specify a deployment name if you don't specify a kit.\n";
+		if ($options{kit}) {
+			($name, $_) = extract_kit_name_and_version($options{kit});
+		} elsif ($options{'link-dev-kit'}) {
+			use File::Basename;
+			$name = File::Basename::basename($options{'link-dev-kit'});
+		} else {
+			printf STDERR "You must specify a deployment name if you don't specify a kit or a dev link target.\n";
 			usage(1);
 		}
-		($name, $_) = extract_kit_name_and_version($options{kit});
 	}
 	$name =~ s/-deployments//;
 
 	validate_repo_name $name or die "Invalid Genesis repo name '$name'\n";
 
 	debug "generating a new Genesis repo, named $name";
-	debug "using kit $options{kit}" if $options{kit};
 
 	debug "checking git config so can git commit later";
 	execute 'git config user.name'
@@ -3406,8 +3429,6 @@ EOF
 	mkdir_or_fail "$root/.genesis/bin";
 	copy_or_fail  $0, "$root/.genesis/bin/genesis";
 	chmod_or_fail 0755, "$root/.genesis/bin/genesis";
-	mkdir_or_fail "$root/dev" unless $options{kit};
-
 	put_file "$root/README.md", <<EOF;
 $name deployments
 ==============================
@@ -3512,9 +3533,16 @@ EOF
 
 	chdir_or_fail $root;
 
-	if ($options{kit}) {
+	if ($options{'link-dev-kit'}) {
+		debug "Kit: linking dev to $abs_target";
+		symlink_or_fail $abs_target, "./dev";
+	} elsif ($options{kit}) {
+		debug "Kit: installing kit $options{kit}";
 		my ($kit, $version) = extract_kit_name_and_version($options{kit});
 		download_kit_tarball($kit, $version);
+	} else {
+		debug "Kit: creating empty ./dev kit directory";
+		mkdir_or_fail "./dev";
 	}
 
 	execute 'git init'

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,10 @@
+# Improvements
+
+- Add `-L|--link-dev-kit <dir>` option to `genesis init` to allow creating a
+  genesis deployment repo using a kit already found on your machine.  Though
+  primarily useful for developing the dev kit itself, it could also be used
+  for utilizing a distributed collection of private kits.
+
 # Bug Fixes
 
 - Resolve issue where CLI flags were being parsed case-insenitively.

--- a/t/init.t
+++ b/t/init.t
@@ -4,8 +4,14 @@ use warnings;
 
 use lib 't';
 use helper;
+use Cwd qw(abs_path);
 
 bosh2_cli_ok;
+
+# Reused variables:
+my $target_dir;
+my $intended_target;
+my $link_target;
 
 qx(rm -rf t/tmp; mkdir -p t/tmp);
 chdir "t/tmp";
@@ -36,10 +42,11 @@ ok ! -d "shield-deployments/dev",                "`genesis init` did not create 
 ok get_file("shield-deployments/.genesis/config") =~ /\ndeployment_type: shield($|\n)/s, "`genesis init` uses the correct deployment-type";
 chdir("shield-deployments");
 output_ok("git status --porcelain", "", "No untracked/changed files exist after a genesis init");
+chdir("..");
 
 qx(rm -rf *-deployments/);
 runs_ok "genesis init -k shield/0.1.0 -d backups back-ups";
-ok -d "backups",                      "`genesis init` created the random-deployments/ directory";
+ok -d "backups",                      "`genesis init` created the backups/ directory";
 ok -d "backups/.genesis",             "`genesis init` created the .genesis/ sub-directory";
 ok -f "backups/.genesis/config",      "`genesis init` created the .genesis/config file";
 ok -d "backups/.genesis/bin",         "`genesis init` created the .genesis/bin sub-directory";
@@ -51,6 +58,44 @@ ok ! -d "backups/dev",                "`genesis init` did not create the dev/ di
 ok get_file("backups/.genesis/config") =~ /\ndeployment_type: back-ups($|\n)/s, "`genesis init` uses the correct deployment-type";
 
 qx(rm -rf backups);
+
+run_fails "genesis init -k shield/0.1.0 -L ../kits/ask-params shouldfail", "`genesis init` fails when specifying both -k and -L";
+qx(rm -rf shouldfail-deployments) if -d "shouldfail-deployments";
+
+runs_ok "genesis init  -L ../kits/ask-params";
+$target_dir = "ask-params-deployments";
+ok -d "$target_dir", "`genesis init` with -L ask-params created the default directory";
+ok -d "$target_dir/.genesis",                       "`genesis init` created the .genesis/ sub-directory";
+ok -f "$target_dir/.genesis/config",                "`genesis init` created the .genesis/config file";
+ok -d "$target_dir/.genesis/bin",                   "`genesis init` created the .genesis/bin sub-directory";
+ok -f "$target_dir/.genesis/bin/genesis",           "`genesis init` embedded a copy of the calling `genesis` script in .genesis/bin";
+ok ! -d "$target_dir/.genesis/kits",                "`genesis init` didn't create the .genesis/kits subdirectory";
+ok -f "$target_dir/README.md",                      "`genesis init` created a README";
+ok -d "$target_dir/dev" && -l "$target_dir/dev",     "`genesis init` created the dev/ directory as a link";
+$intended_target = abs_path('../kits/ask-params');
+$link_target = readlink("$target_dir/dev");
+ok $link_target eq $intended_target,               "`genesis init` correctly linked to the intended target ('$link_target' == '$intended_target')";
+ok get_file("$target_dir/.genesis/config") =~ /\ndeployment_type: ask-params($|\n)/s, "`genesis init` uses the correct deployment-type";
+qx(rm -rf $target_dir) if -d "$target_dir";
+
+runs_ok "genesis init  -L ../kits/ask-params mytest";
+$target_dir = "mytest-deployments";
+ok -d "$target_dir", "`genesis init` with -L ask-params created the my directory";
+ok -d "$target_dir/.genesis",                       "`genesis init` created the .genesis/ sub-directory";
+ok -f "$target_dir/.genesis/config",                "`genesis init` created the .genesis/config file";
+ok -d "$target_dir/.genesis/bin",                   "`genesis init` created the .genesis/bin sub-directory";
+ok -f "$target_dir/.genesis/bin/genesis",           "`genesis init` embedded a copy of the calling `genesis` script in .genesis/bin";
+ok ! -d "$target_dir/.genesis/kits",                "`genesis init` didn't create the .genesis/kits subdirectory";
+ok -f "$target_dir/README.md",                      "`genesis init` created a README";
+ok -d "$target_dir/dev" && -l "$target_dir/dev",    "`genesis init` created the dev/ directory as a link";
+$intended_target = abs_path('../kits/ask-params');
+$link_target = readlink("$target_dir/dev");
+ok $link_target eq $intended_target,               "`genesis init` correctly linked to the intended target ('$link_target' == '$intended_target')";
+ok get_file("$target_dir/.genesis/config") =~ /\ndeployment_type: mytest($|\n)/s, "`genesis init` uses the correct deployment-type";
+qx(rm -rf $target_dir) if -d "$target_dir";
+
+run_fails "genesis init -L ../kits/notakit shouldfail", "`genesis init` fails when specifying a non-existing directory for -L argument";
+qx(rm -rf shouldfail) if -d "shouldfail";
 
 mkdir "random-deployments";
 run_fails "genesis init random", "`genesis init` fails when the destination it would use already exists";


### PR DESCRIPTION
# Improvements

- Add `-L|--link-dev-kit <dir>` option to `genesis init` to allow creating a
  genesis deployment repo using a kit already found on your machine.  Though
  primarily useful for developing the dev kit itself, it could also be used
  for utilizing a distributed collection of private kits.