### PR TITLE
Check bosh environment that genesis uses so it errors better and faster

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -3185,11 +3185,25 @@ sub tablify {
 # bosh_target_for $env
 sub bosh_target_for {
 	my ($env) = @_;
-	return $ENV{GENESIS_BOSH_ENVIRONMENT} if defined($ENV{GENESIS_BOSH_ENVIRONMENT});
-	return $ENV{BOSH_ENVIRONMENT} if defined($ENV{BOSH_ENVIRONMENT});
-	return get_key($env, 'params.bosh')
-	    || get_key($env, 'params.env')
-	    || die "Could not find the `params.bosh' or `params.env' key in $env!\n";
+	if (defined($ENV{GENESIS_BOSH_ENVIRONMENT})) {
+		return $ENV{GENESIS_BOSH_ENVIRONMENT} if (system($BOSH, "-e", $ENV{GENESIS_BOSH_ENVIRONMENT}, "env") == 0 );
+		die "No such host: $ENV{GENESIS_BOSH_ENVIRONMENT} from ENV{GENESIS_BOSH_ENVIRONMENT} for the BOSH Direcor.\n";
+	}
+	if (defined($ENV{BOSH_ENVIRONMENT})) {
+		return $ENV{BOSH_ENVIRONMENT} if (system($BOSH, "-e", $ENV{BOSH_ENVIRONMENT}, "env") == 0);
+		die "No such host: $ENV{BOSH_ENVIRONMENT} from ENV{BOSH_ENVIRONMENT} for the BOSH Direcor you are targeting at.\n";
+	}
+	my $bosh = get_key($env, 'params.bosh');
+	if (defined($bosh)) {
+		return $bosh if (system($BOSH, "-e", $bosh, "env") == 0);
+		die "No such host: $bosh for the BOSH Direcor which you configured in params.bosh.\n";
+	 }
+	$bosh = get_key($env, 'params.env');
+	if (defined($bosh)) {
+		 return $bosh if (system($BOSH, "-e", $bosh, "env") == 0);
+		 die "No such host: $bosh for the BOSH Direcor which you configured in params.env. You can specify your BOSH Director alias name in params.bosh.\n";
+	}
+	die "Could not find the `params.bosh' or `params.env' key in $env!\n";
 }
 
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -3188,24 +3188,24 @@ sub bosh_target_for {
 	if (defined($ENV{GENESIS_BOSH_ENVIRONMENT})) {
 		`$BOSH "-e" $ENV{GENESIS_BOSH_ENVIRONMENT} "env" &>/dev/null`;
 		return $ENV{GENESIS_BOSH_ENVIRONMENT} if ($? == 0);
-		die "No such host: $ENV{GENESIS_BOSH_ENVIRONMENT} from ENV{GENESIS_BOSH_ENVIRONMENT} for the BOSH Direcor.\n";
+		die "No such host: $ENV{GENESIS_BOSH_ENVIRONMENT} from GENESIS_BOSH_ENVIRONMENT environment variable for the BOSH Director.\n";
 	}
 	if (defined($ENV{BOSH_ENVIRONMENT})) {
 		`$BOSH "-e" $ENV{BOSH_ENVIRONMENT} "env" &>/dev/null`;
 		return $ENV{BOSH_ENVIRONMENT} if ($? == 0);
-		die "No such host: $ENV{BOSH_ENVIRONMENT} from ENV{BOSH_ENVIRONMENT} for the BOSH Direcor you are targeting at.\n";
+		die "No such host: $ENV{BOSH_ENVIRONMENT} from BOSH_ENVIRONMENT environment variable for the BOSH Director you are targeting at.\n";
 	}
 	my $bosh = get_key($env, 'params.bosh');
 	if (defined($bosh)) {
 		`$BOSH "-e" $bosh "env" &>/dev/null`;
 		return $bosh if ($? == 0);
-		die "No such host: $bosh for the BOSH Direcor which you configured in params.bosh.\n";
+		die "No such host: $bosh for the BOSH Director which you configured in params.bosh.\n";
 	 }
 	$bosh = get_key($env, 'params.env');
 	if (defined($bosh)) {
 		`$BOSH "-e" $bosh "env" &>/dev/null`;
 		return $bosh if ($? == 0);
-		die "No such host: $bosh for the BOSH Direcor which you configured in params.env. You can specify your BOSH Director alias name in params.bosh.\n";
+		die "No such host: $bosh for the BOSH Director which you configured in params.env. You can specify your BOSH Director alias name in params.bosh.\n";
 	}
 	die "Could not find the `params.bosh' or `params.env' key in $env!\n";
 }

--- a/bin/genesis
+++ b/bin/genesis
@@ -3186,22 +3186,26 @@ sub tablify {
 sub bosh_target_for {
 	my ($env) = @_;
 	if (defined($ENV{GENESIS_BOSH_ENVIRONMENT})) {
-		return $ENV{GENESIS_BOSH_ENVIRONMENT} if (system($BOSH, "-e", $ENV{GENESIS_BOSH_ENVIRONMENT}, "env") == 0 );
+		`$BOSH "-e" $ENV{GENESIS_BOSH_ENVIRONMENT} "env" &>/dev/null`;
+		return $ENV{GENESIS_BOSH_ENVIRONMENT} if ($? == 0);
 		die "No such host: $ENV{GENESIS_BOSH_ENVIRONMENT} from ENV{GENESIS_BOSH_ENVIRONMENT} for the BOSH Direcor.\n";
 	}
 	if (defined($ENV{BOSH_ENVIRONMENT})) {
-		return $ENV{BOSH_ENVIRONMENT} if (system($BOSH, "-e", $ENV{BOSH_ENVIRONMENT}, "env") == 0);
+		`$BOSH "-e" $ENV{BOSH_ENVIRONMENT} "env" &>/dev/null`;
+		return $ENV{BOSH_ENVIRONMENT} if ($? == 0);
 		die "No such host: $ENV{BOSH_ENVIRONMENT} from ENV{BOSH_ENVIRONMENT} for the BOSH Direcor you are targeting at.\n";
 	}
 	my $bosh = get_key($env, 'params.bosh');
 	if (defined($bosh)) {
-		return $bosh if (system($BOSH, "-e", $bosh, "env") == 0);
+		`$BOSH "-e" $bosh "env" &>/dev/null`;
+		return $bosh if ($? == 0);
 		die "No such host: $bosh for the BOSH Direcor which you configured in params.bosh.\n";
 	 }
 	$bosh = get_key($env, 'params.env');
 	if (defined($bosh)) {
-		 return $bosh if (system($BOSH, "-e", $bosh, "env") == 0);
-		 die "No such host: $bosh for the BOSH Direcor which you configured in params.env. You can specify your BOSH Director alias name in params.bosh.\n";
+		`$BOSH "-e" $bosh "env" &>/dev/null`;
+		return $bosh if ($? == 0);
+		die "No such host: $bosh for the BOSH Direcor which you configured in params.env. You can specify your BOSH Director alias name in params.bosh.\n";
 	}
 	die "Could not find the `params.bosh' or `params.env' key in $env!\n";
 }


### PR DESCRIPTION
This fix issue # 167.

Passed `make test` and tested it on bosh-lite deployment.