### PR TITLE
Genesis secrets refactor

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -750,10 +750,10 @@ sub check_secret {
 	if ($type eq 'x509') {
 		if (grep {$_ eq '--signed-by'} @$cmd) {
 			$type = "certificate";
-			@keys = qw(certificate);
+			@keys = qw(certificate combined key);
 		} else {
 			$type = "CA certificate";
-			@keys = qw(certificate);
+			@keys = qw(certificate combined crl key serial);
 		}
 	} elsif ($type eq 'rsa') {
 		@keys = qw(private public);

--- a/bin/genesis
+++ b/bin/genesis
@@ -3831,7 +3831,7 @@ EOF
 sub {
 	my %options;
 	options(\@_, \%options, qw/
-		force
+		force|force-rotate-all|f
 		vault=s
 	/);
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -651,6 +651,8 @@ sub dereference_params {
 sub safe_commands {
 	my ($creds, %options) = @_;
 	my @cmds;
+	my $force_rotate = ($options{scope}||'') eq 'force';
+	my $missing_only = ($options{scope}||'') eq 'add';
 	for my $path (sort keys %$creds) {
 		if (! ref $creds->{$path}) {
 			my $cmd = $creds->{$path};
@@ -658,12 +660,12 @@ sub safe_commands {
 
 			if ($cmd =~ m/^(ssh|rsa)\s+(\d+)(\s+fixed)?$/) {
 				my $safe = [$1, $2, "secret/$options{prefix}/$path"];
-				push @$safe, "--no-clobber", "--quiet" if $3 && !$options{force_rotate};
+				push @$safe, "--no-clobber", "--quiet" if ($3 && !$force_rotate) || $missing_only;
 				push @cmds, $safe;
 
 			} elsif ($cmd =~ m/^dhparams?\s+(\d+)(\s+fixed)?$/) {
 				my $safe = ['dhparam', $1, "secret/$options{prefix}/$path"];
-				push @$safe, "--no-clobber", "--quiet" if $2 && !$options{force_rotate};
+				push @$safe, "--no-clobber", "--quiet" if ($2 && !$force_rotate) || $missing_only;
 				push @cmds, $safe;
 
 			} else {
@@ -681,12 +683,12 @@ sub safe_commands {
 						@allowed_chars = ("--policy", $valid_chars);
 					}
 					my $safe = ['gen', $len, @allowed_chars, "secret/$options{prefix}/$path", $attr];
-					push @$safe, "--no-clobber", "--quiet" if $fixed && !$options{force_rotate};
+					push @$safe, "--no-clobber", "--quiet" if ($fixed && !$force_rotate) || $missing_only;
 					push @cmds, $safe;
 					if ($format) {
 						$destination ||= "$attr-$format";
 						my $safe = ["fmt", $format , "secret/$options{prefix}/$path", $attr, $destination];
-						push @$safe, "--no-clobber", "--quiet" if $fixed && !$options{force_rotate};
+						push @$safe, "--no-clobber", "--quiet" if ($fixed && !$force_rotate) || $missing_only;
 						push @cmds, $safe;
 					}
 
@@ -705,13 +707,17 @@ sub safe_commands {
 sub cert_commands {
 	my ($certs, %options) = @_;
 	my @cmds;
+	my $force_rotate = ($options{scope}||'') eq 'force';
+	my $missing_only = ($options{scope}||'') eq 'add';
 	for my $path (sort keys %$certs) {
-		my @cmd = ("safe", "x509", "issue", "secret/$options{prefix}/$path/ca", "--name", "ca.$path",
+		my @cmd = (
+			"x509",
+			"issue",
+			"secret/$options{prefix}/$path/ca",
+			"--name", "ca.$path",
 			"--ca");
-		push @cmd, "--no-clobber", "--quiet" if !$options{force_rotate};
-		system @cmd;
-
-		die "Failure autogenerating certificates.\n" if ($? != 0);
+		push @cmd, "--no-clobber", "--quiet" if !$force_rotate; # All CA certs are considered kept
+		push @cmds, \@cmd;
 
 		for my $cert (sort keys %{$certs->{$path}}) {
 			next if $cert eq "ca";
@@ -722,12 +728,58 @@ sub cert_commands {
 			$c->{valid_for} ||= "1y";
 
 			my @name_flags = map {( "--name", dereference_params($_, $options{env}) )} @{$c->{names}};
-			system "safe", "x509", "issue", "secret/$options{prefix}/$path/$cert", "--ttl", $c->{valid_for},
-				@name_flags, "--signed-by", "secret/$options{prefix}/$path/ca";
-			die "Failure autogenerating certificates.\n" if ($? != 0);
+			my @cmd = (
+				"x509",
+				"issue",
+				"secret/$options{prefix}/$path/$cert",
+				"--ttl", $c->{valid_for},
+				@name_flags,
+				"--signed-by", "secret/$options{prefix}/$path/ca");
+			push @cmd, "--no-clobber", "--quiet" if $missing_only;
+			push @cmds, \@cmd;
 		}
 	}
 	return @cmds;
+}
+
+sub check_secret {
+	my ($cmd, %options) = @_;
+	my (@keys);
+	my $type = $cmd->[0];
+	my $path = $cmd->[2];
+	if ($type eq 'x509') {
+		if (grep {$_ eq '--signed-by'} @$cmd) {
+			$type = "certificate";
+			@keys = qw(certificate);
+		} else {
+			$type = "CA certificate";
+			@keys = qw(certificate);
+		}
+	} elsif ($type eq 'rsa') {
+		@keys = qw(private public);
+	} elsif ($type eq 'ssh') {
+		@keys = qw(private public fingerprint);
+	} elsif ($type eq 'dhparam') {
+		@keys = qw(dhparam-pem);
+	} elsif ($type eq 'gen') {
+		$type = 'random';
+		my $path_offset = $cmd->[1] eq '-l' ? 3 : 2;
+		$path_offset += 2 if $cmd->[$path_offset] eq '--policy';
+		$path = $cmd->[$path_offset];
+		@keys = ($cmd->[$path_offset + 1]);
+	} elsif ($type eq 'fmt') {
+		$type = 'random/formatted';
+		@keys = ($cmd->[4]);
+	} else {
+		die "Unrecognized credential or certificate command: '".join(" ", @$cmd)."'\n";
+	}
+
+	my @missing = ();
+	for (@keys) {
+		system('safe', 'exists', "$path:$_");
+		push @missing, ["[$type]", "$path:$_"] if $?;
+	}
+	return @missing;
 }
 
 ###########################################################################
@@ -3112,20 +3164,27 @@ sub target_vault {
 #                  target       => "my-vault",
 #                  env          => "us-east-sandbox",
 #                  prefix       => "us/east/sandbox",
-#                  force_rotate => 0;
+#                  scope        => 'rotate'; # or scope => '' or undef
 #
 ## generate all credentials (including 'fixed' creds)
 # vaultify_secrets $kit_metadata,
 #                  target       => "my-vault",
 #                  env          => "us-east-sandbox",
 #                  prefix       => "us/east/sandbox",
-#                  force_rotate => 1;
+#                  scope        => 'force';
+#
+## generate only missing credentials
+# vaultify_secrets $kit_metadata,
+#                  target       => "my-vault",
+#                  env          => "us-east-sandbox",
+#                  prefix       => "us/east/sandbox",
+#                  scope        => 'add';
 #
 sub vaultify_secrets {
 	my ($meta, %options) = @_;
 	$options{env} or die "generate_secrets() was not given an 'env' option.\n";
 
-	my $creds = active_credentials($meta, $options{subkits} || []);
+	my $creds = active_credentials($meta, $options{subkits} || {});
 	if (%$creds) {
 		explain " - auto-generating credentials (in secret/$options{prefix})...\n";
 		for (safe_commands $creds, %options) {
@@ -3136,12 +3195,44 @@ sub vaultify_secrets {
 		explain " - no credentials need to be generated.\n";
 	}
 
-	my $certs = active_certificates($meta, $options{subkits} || []);
+	my $certs = active_certificates($meta, $options{subkits} || {});
 	if (%$certs) {
 		explain " - auto-generating certificates (in secret/$options{prefix})...\n";
-		cert_commands($certs, %options);
+		for (cert_commands $certs, %options) {
+			system('safe', @$_);
+			die "Failure autogenerating certificates.\n" if ($? != 0);
+		}
 	} else {
 		explain " - no certificates need to be generated.\n";
+	}
+}
+
+sub check_secrets {
+	my ($meta, %options) = @_;
+	$options{env} or die "generate_secrets() was not given an 'env' option.\n";
+
+	my @missing = ();
+	for (safe_commands(active_credentials($meta, $options{subkits}||{}),%options)) {
+		my @miss = check_secret($_, %options);
+		if (@miss) {
+			push @missing, @miss;
+		}
+	}
+	for (cert_commands(active_certificates($meta, $options{subkits}||{}),%options)) {
+		my @miss = check_secret($_, %options);
+		if (@miss) {
+			push @missing, @miss;
+		}
+	}
+	if (@missing) {
+		my $suf = scalar(@missing) == 1 ? '' : 's';
+		printf "Missing %d credential%s or certificate%s:\n  * %s\n",
+			scalar(@missing), $suf, $suf,
+			join ("\n  * ", map {join " ", @$_} @missing);
+		return 1;
+	} else {
+		print "All credentials and certificates present.\n";
+		return 0;
 	}
 }
 
@@ -3663,7 +3754,7 @@ sub {
 		explain "Generating secrets / credentials (in secret/$prefix)...\n";
 		vaultify_secrets($meta, env          => $name,
 		                        prefix       => $prefix,
-		                        force_rotate => 1,
+		                        scope        => 'force',
 		                        subkits      => [@subkits]);
 	} else {
 		explain "Skipping generation of secret / credentials.\n";
@@ -3711,29 +3802,54 @@ sub {
 
 command("secrets", <<EOF,
 genesis v$VERSION
-USAGE: genesis secrets [--rotate] [--vault target] deployment-env.yml
+USAGE: genesis secrets [check|add|rotate [--force]][--vault target] deployment-env.yml
 
-Generates new secrets for your deployment. If any credentials were marked by
-the kit as `fixed', they are not updated. Useful for credential rotation, and
-generating credentials after `genesis new --no-secrets' was called.
+Checks, adds or rotates secrets for your deployment.
+
+  * check:  Checks that all required secrets are present.  Returns a exit code
+            of 1 if any are missing, and lists them, otherwise states all
+            secrets are present and exits with 0.
+
+  * add:    Generates any missing secrets required by the deployment.  Useful
+            to generate credentials after upgrading kits or if `genesis new
+            --no-secrets` was used to create the deployment.
+
+  * rotate: Generates new secrets for your deployment. If any credentials were
+            marked by the kit as `fixed', they are not updated unless the 
+            `--force` option was also specified.
 
 OPTIONS
 $GLOBAL_USAGE
-      --force-rotate-all  Rotate *ALL* credentials, including any credentials
-                          that the kit defined as `fixed'. This is very dangerous.
-      --vault             The name of a `safe' target (a Vault) to store newly
-                          generated credentials in.
+  -f, --force        Rotate *ALL* credentials, including any credentials that
+                     the kit defined as `fixed'. This is very dangerous.  Only 
+                     applies to `rotate`
+
+      --vault        The name of a `safe' target (a Vault) to store newly
+                     generated credentials in.
+
 EOF
 sub {
 	my %options;
 	options(\@_, \%options, qw/
-		force-rotate-all
+		force
 		vault=s
 	/);
-	usage(1) if @_ != 1;
+
+	my ($action,$name) = @_;
+	if (@_ == 1) {
+		$name = $action;
+		$action = 'check';
+	}
+	usage(1) if @_ < 1 or @_ > 2;
+    usage(1, "Must specify check, add or rotate, not $action")
+		unless (grep {$_ eq $action} qw(check add rotate));
+	if ($options{force}) {
+		usage(1, "Can only specify --force with rotate") if $action ne 'rotate';
+		$action = 'force';
+	}
+
 	check_prereqs;
 
-	my ($name) = @_;
 	$name =~ s/\.ya?ml$//;
 	my $deployment = $name . "-" . deployment_suffix;
 	(my $prefix = $deployment) =~ s|-|/|g;
@@ -3741,10 +3857,21 @@ sub {
 	my ($kit, $version) = kit_name_and_version_for($name);
 	my $meta = read_kit_metadata($kit, $version);
 	target_vault($options{vault});
-	vaultify_secrets($meta, env          => $name,
-	                        prefix       => $prefix,
-	                        subkits      => get_key($name, 'kit.subkits', []),
-	                        force_rotate => $options{"force-rotate-all"});
+
+	if ($action eq "check") {
+		exit check_secrets(   $meta,
+			env       => $name,
+			prefix    => $prefix,
+			subkits   => get_key($name, 'kit.subkits', [])
+		);
+	} else {
+		vaultify_secrets($meta,
+			env       => $name,
+			prefix    => $prefix,
+			subkits   => get_key($name, 'kit.subkits', []),
+			scope     => $action
+		);
+	}
 });
 
 # }}}

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,19 @@
+# Improvements
+
+* Refactored the `genesis secrets` command to take a sub-command of `check`,
+  `add`, or `rotate`.  Rotate behaves the same way as the original command,
+  including supporting a `--force` option to force rotation of ALL
+  secrets.<br><br>The `add` command allows you to generate any missing secrets
+  while leaving existing secrets in place.  Useful for when you run `genesis
+    new --no-secrets` or after upgrading the kit to a version that may add new
+    secret requirements.<br><br>The `check` command will allow you to check if
+    any secrets are missing.  It will list the missing secrets, and for
+    automation purpose, will return an exit code of 1 if any are missing, 0
+    otherwise.
+    
+## Breaking Change
+    
+If you ommit a subcommand, it defaults to `check`.  If you have any automation
+that uses this, please update to specify `rotate` explicitly.  Furthermore,
+the `--force-rotate-all` has been shortened to `--force`, but still accepts
+the original.

--- a/t/secrets.t
+++ b/t/secrets.t
@@ -132,7 +132,6 @@ matches $msg, qr/All credentials and certificates present./, "No missing secrets
 # Test only missing secrets are regenerated
 %before = %after;
 for (@$removed) {
-  diag "$v/$_ was '$before{$_}'";
   runs_ok "safe delete -f $v/$_", "removed $v/$_  for testing";
   no_secret "$v/$_", "$v/$_ should not exist";
 }
@@ -234,6 +233,25 @@ no_secret "$v/auto-generated-certs-b/server";
 $v = "secret/west/us/sandbox/certificates";
 runs_ok "safe delete -Rf $v", "clean up certs for rotation testing";
 no_secret "$v/auto-generated-certs-a/ca:certificate";
+($pass,$rc,$msg) = run_fails "genesis secrets check west-us-sandbox --vault unit-tests", 1;
+matches $msg, qr#Missing 16 credentials or certificates:#, "Correct number of secrets reported missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-a/ca:certificate#,  "CA cert certificate missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-a/ca:combined#,  "CA cert combined missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-a/ca:crl#,  "CA cert crl missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-a/ca:key#,  "CA cert key missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-a/ca:serial#,  "CA cert serial missing";
+matches $msg, qr#  \* \[certificate] $v/auto-generated-certs-a/server:certificate#, "Cert certificate missing";
+matches $msg, qr#  \* \[certificate] $v/auto-generated-certs-a/server:combined#, "Cert combined missing";
+matches $msg, qr#  \* \[certificate] $v/auto-generated-certs-a/server:key#, "Cert key missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-b/ca:certificate#,  "CA cert certificate missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-b/ca:combined#,  "CA cert combined missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-b/ca:crl#,  "CA cert crl missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-b/ca:key#,  "CA cert key missing";
+matches $msg, qr#  \* \[CA certificate] $v/auto-generated-certs-b/ca:serial#,  "CA cert serial missing";
+matches $msg, qr#  \* \[certificate] $v/auto-generated-certs-b/server:certificate#, "Cert certificate missing";
+matches $msg, qr#  \* \[certificate] $v/auto-generated-certs-b/server:combined#, "Cert combined missing";
+matches $msg, qr#  \* \[certificate] $v/auto-generated-certs-b/server:key#, "Cert key missing";
+
 runs_ok "genesis secrets rotate --vault unit-tests west-us-sandbox", "genesis secrets creates our certs";
 have_secret "$v/auto-generated-certs-a/server:certificate";
 my $cert = secret "$v/auto-generated-certs-a/server:certificate";

--- a/t/secrets.t
+++ b/t/secrets.t
@@ -57,6 +57,21 @@ my $rotated = [qw[
 
   auth/cf/uaa:shared_secret
 ]];
+
+my $removed = [qw[
+  test/random:username
+
+  test/rsa/strong:public
+  test/rsa/strong:private
+
+  test/fixed/ssh:public
+  test/fixed/ssh:private
+  test/fixed/ssh:fingerprint
+  
+  test/fmt/sha512/default:random
+  test/fmt/sha512/default:random-crypt-sha512
+]];
+
 my $fixed = [qw[
   test/fixed/random:username
 
@@ -86,7 +101,7 @@ is length($before{'test/random:password'}), 109,
 
 like secret("$v/test/random:limited"), qr/^[a-z]{16}$/, "It is possible to limit chars used for random credentials";
 
-runs_ok "genesis secrets us-east-sandbox --vault unit-tests";
+runs_ok "genesis secrets rotate us-east-sandbox --vault unit-tests";
 my %after;
 for (@$rotated, @$fixed) {
   have_secret "$v/$_";
@@ -101,13 +116,48 @@ for (@$fixed) {
 }
 
 %before = %after;
-runs_ok "genesis secrets --force-rotate-all us-east-sandbox --vault unit-tests";
+runs_ok "genesis secrets rotate --force us-east-sandbox --vault unit-tests";
 for (@$rotated, @$fixed) {
   have_secret "$v/$_";
   $after{$_} = secret "$v/$_";
 }
 for (@$rotated, @$fixed) {
   isnt $before{$_}, $after{$_}, "$_ should be rotated (all)";
+}
+
+# Test that nothing is missing
+my ($pass,$rc,$msg) = runs_ok "genesis secrets check us-east-sandbox --vault unit-tests";
+matches $msg, qr/All credentials and certificates present./, "No missing secrets";
+
+# Test only missing secrets are regenerated
+%before = %after;
+for (@$removed) {
+  diag "$v/$_ was '$before{$_}'";
+  runs_ok "safe delete -f $v/$_", "removed $v/$_  for testing";
+  no_secret "$v/$_", "$v/$_ should not exist";
+}
+($pass,$rc,$msg) = run_fails "genesis secrets check us-east-sandbox --vault unit-tests", 1;
+matches $msg, qr#Missing 8 credentials or certificates:#, "Correct number of secrets reported missing";
+matches $msg, qr#  \* \[random\] $v/test/random:username#, "Random-type secret missing";
+matches $msg, qr#  \* \[rsa\] $v/test/rsa/strong:public#, "RSA-type public secret missing";
+matches $msg, qr#  \* \[rsa\] $v/test/rsa/strong:private#, "RSA-type private secret missing";
+matches $msg, qr#  \* \[ssh\] $v/test/fixed/ssh:public#, "SSH-type public secret missing";
+matches $msg, qr#  \* \[ssh\] $v/test/fixed/ssh:private#, "SSH-type private secret missing";
+matches $msg, qr#  \* \[ssh\] $v/test/fixed/ssh:fingerprint#, "SSH-type fingerprint secret missing";
+matches $msg, qr#  \* \[random\] $v/test/fmt/sha512/default:random#, "Random-type secret missing";
+matches $msg, qr#  \* \[random/formatted\] $v/test/fmt/sha512/default:random-crypt-sha512#, "Random-type formatted secret missing";
+
+runs_ok "genesis secrets add us-east-sandbox --vault unit-tests";
+for (@$rotated, @$fixed) {
+  have_secret "$v/$_";
+  $after{$_} = secret "$v/$_";
+}
+for my $path (@$rotated, @$fixed) {
+  if (grep {$_ eq $path} @$removed) {
+    isnt $before{$path}, $after{$path}, "$path should be recreated with a new value";
+  } else {
+    is $before{$path}, $after{$path}, "$path should be left unchanged";
+  }
 }
 
 reprovision kit => 'asksecrets';
@@ -184,26 +234,40 @@ no_secret "$v/auto-generated-certs-b/server";
 $v = "secret/west/us/sandbox/certificates";
 runs_ok "safe delete -Rf $v", "clean up certs for rotation testing";
 no_secret "$v/auto-generated-certs-a/ca:certificate";
-runs_ok "genesis secrets --vault unit-tests west-us-sandbox", "genesis secrets creates our certs";
+runs_ok "genesis secrets rotate --vault unit-tests west-us-sandbox", "genesis secrets creates our certs";
 have_secret "$v/auto-generated-certs-a/server:certificate";
 my $cert = secret "$v/auto-generated-certs-a/server:certificate";
 have_secret "$v/auto-generated-certs-a/ca:certificate";
 my $ca = secret "$v/auto-generated-certs-a/ca:certificate";
 
-runs_ok "genesis secrets --vault unit-tests west-us-sandbox", "genesis secrets doesnt rotate the CA";
+runs_ok "genesis secrets rotate --vault unit-tests west-us-sandbox", "genesis secrets doesn't rotate the CA";
 have_secret "$v/auto-generated-certs-a/ca:certificate";
 my $new_ca = secret "$v/auto-generated-certs-a/ca:certificate";
 is $ca, $new_ca, "CA cert doesnt change under normal secret rotation";
 
-runs_ok "genesis secrets --vault unit-tests west-us-sandbox", "genesis secrets rotates regular certs";
+runs_ok "genesis secrets add --vault unit-tests west-us-sandbox", "genesis secrets --missing-only doesn't rotate the CA";
+have_secret "$v/auto-generated-certs-a/ca:certificate";
+$new_ca = secret "$v/auto-generated-certs-a/ca:certificate";
+is $ca, $new_ca, "CA cert doesnt change under normal secret rotation";
+
+$cert = secret "$v/auto-generated-certs-a/server:certificate";
+runs_ok "genesis secrets add --vault unit-tests west-us-sandbox", "genesis secrets --missing-only doesn't rotate regular certs";
 have_secret "$v/auto-generated-certs-a/server:certificate";
 my $new_cert = secret "$v/auto-generated-certs-a/server:certificate";
+is $cert, $new_cert, "Certificates do not change if existing";
+
+runs_ok "genesis secrets rotate --vault unit-tests west-us-sandbox", "genesis secrets rotates regular certs";
+have_secret "$v/auto-generated-certs-a/server:certificate";
+$new_cert = secret "$v/auto-generated-certs-a/server:certificate";
 isnt $cert, $new_cert, "Certificates are rotated normally";
 
-runs_ok "genesis secrets --vault unit-tests west-us-sandbox --force-rotate-all", "genesis secrets --force-rotate-all regenerates CA certs";
+$cert = secret "$v/auto-generated-certs-a/server:certificate";
+runs_ok "genesis secrets rotate --force --vault unit-tests west-us-sandbox", "genesis secrets --force-rotate-all regenerates CA certs";
 have_secret "$v/auto-generated-certs-a/ca:certificate";
 $new_ca = secret "$v/auto-generated-certs-a/ca:certificate";
 isnt $ca, $new_ca, "CA certificate changes under force-rotation";
+$new_cert = secret "$v/auto-generated-certs-a/server:certificate";
+isnt $cert, $new_cert, "Certificates are rotated when forced.";
 
 chdir $TOPDIR;
 teardown_vault;

--- a/t/secrets.t
+++ b/t/secrets.t
@@ -262,7 +262,15 @@ $new_cert = secret "$v/auto-generated-certs-a/server:certificate";
 isnt $cert, $new_cert, "Certificates are rotated normally";
 
 $cert = secret "$v/auto-generated-certs-a/server:certificate";
-runs_ok "genesis secrets rotate --force --vault unit-tests west-us-sandbox", "genesis secrets --force-rotate-all regenerates CA certs";
+runs_ok "genesis secrets rotate --force-rotate-all --vault unit-tests west-us-sandbox", "genesis secrets --force-rotate-all regenerates CA certs";
+have_secret "$v/auto-generated-certs-a/ca:certificate";
+$new_ca = secret "$v/auto-generated-certs-a/ca:certificate";
+isnt $ca, $new_ca, "CA certificate changes under force-rotation";
+$new_cert = secret "$v/auto-generated-certs-a/server:certificate";
+isnt $cert, $new_cert, "Certificates are rotated when forced.";
+
+$cert = secret "$v/auto-generated-certs-a/server:certificate";
+runs_ok "genesis secrets rotate -f --vault unit-tests west-us-sandbox", "genesis secrets -f regenerates CA certs";
 have_secret "$v/auto-generated-certs-a/ca:certificate";
 $new_ca = secret "$v/auto-generated-certs-a/ca:certificate";
 isnt $ca, $new_ca, "CA certificate changes under force-rotation";


### PR DESCRIPTION
Extents `genesis secrets` to allow you to check if all secrets are present, and add just the missing ones without rotating the existing ones.

Fixes #171 

----

USAGE: genesis secrets [check|add|rotate [--force]][--vault target] deployment-env.yml

Checks, adds or rotates secrets for your deployment.

  * check:  
    - Checks that all required secrets are present.  Returns a exit code
            of 1 if any are missing, and lists them, otherwise states all
            secrets are present and exits with 0.

  * add:
    - Generates any missing secrets required by the deployment.  Useful
            to generate credentials after upgrading kits or if `genesis new
            --no-secrets` was used to create the deployment.

  * rotate:
    -  Generates new secrets for your deployment. If any credentials were
            marked by the kit as `fixed', they are not updated unless the
            `--force` option was also specified.