### PR TITLE
Add vault policies

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1281,7 +1281,7 @@ sub deploy_manifest {
 	my ($env, $options) = @_;
 	$ENV{REDACT} = '';
 	my $dir = workdir;
-	my $target = ''; 
+	my $target = '';
 	my $create_env = is_create_env($env);
 
 	if (!$create_env) {
@@ -4719,13 +4719,13 @@ Checks, adds or rotates secrets for your deployment.
             --no-secrets` was used to create the deployment.
 
   * rotate: Generates new secrets for your deployment. If any credentials were
-            marked by the kit as `fixed', they are not updated unless the 
+            marked by the kit as `fixed', they are not updated unless the
             `--force` option was also specified.
 
 OPTIONS
 $GLOBAL_USAGE
   -f, --force        Rotate *ALL* credentials, including any credentials that
-                     the kit defined as `fixed'. This is very dangerous.  Only 
+                     the kit defined as `fixed'. This is very dangerous.  Only
                      applies to `rotate`
 
       --vault        The name of a `safe' target (a Vault) to store newly
@@ -5001,7 +5001,7 @@ $GLOBAL_USAGE
                 (dev mode).
 
   -d, --dev     Compile based off of a dev-kit (./dev). If not specified,
-                genesis will compile based off of ./<name>-genesis-kit. 
+                genesis will compile based off of ./<name>-genesis-kit.
                 Automatically set if run from inside a genesis deployments directory.
 EOF
 sub {

--- a/bin/genesis
+++ b/bin/genesis
@@ -4612,7 +4612,7 @@ EOF
 	my @stemcells = split("\n",$pipeline->{stemcells});
 	print $OUT <<"EOF";
 
-  stemcells:${\(scalar(keys %{$pipeline->{stemcells}}) ? "" : " []")}
+  stemcells:${\(scalar(keys %{$pipeline->{stemcells}}) ? "" : " {}")}
 EOF
 	foreach my $alias (keys %{$pipeline->{stemcells}}) {
 		print $OUT <<"EOF"

--- a/bin/genesis
+++ b/bin/genesis
@@ -74,9 +74,10 @@ sub valid_envs {
 		next unless $json && $json->{params} && $json->{params}{env};
 		(my $label= $_) =~ s/\.yml$//;
 		$envs{$label} = {
-			file => $_,
-			env  => $json->{params}{env},
-			bosh => $json->{params}{bosh} || $json->{params}{env}
+			file  => $_,
+			env   => $json->{params}{env},
+			vault => $json->{params}{vault} || join('/',(split('-', $json->{params}{env}))),
+			bosh  => $json->{params}{bosh}  || $json->{params}{env}
 		}
 	}
 	return %envs;
@@ -4084,6 +4085,20 @@ sub {
 	|Would you like to automatically keep your stemcells up to date?
 	|EOF
 
+	my %chosen_envs;
+	($pipeline{boshes},$pipeline{stemcells},%chosen_envs) = prompt_for_boshes_and_stemcells_for(!$pipeline{skip_upkeep}, %envs);
+
+	$pipeline{layouts} = prompt_for_layouts_for(%chosen_envs);
+
+	$pipeline{errands} = prompt_for_list("line",clean_heredoc(<<"	|EOF"), 'errand');
+	|Enter any errands you'd like to use to test your deployments
+	|e.g.: smoke-tests
+	|EOF
+
+	$pipeline{locker} = prompt_for_locker();
+
+	$pipeline{vault} = prompt_for_vault($pipeline{name},%chosen_envs);
+
 	$pipeline{git} = prompt_for_git($pipeline{name});
 
 	do {
@@ -4091,19 +4106,6 @@ sub {
 		explain "\n#r{ERROR: You must have at least one notification system!}"
 			unless %{$pipeline{notifications}};
 	} until (%{$pipeline{notifications}});
-
-	$pipeline{locker} = prompt_for_locker();
-
-	$pipeline{vault} = prompt_for_vault($pipeline{name});
-
-	($pipeline{boshes},$pipeline{stemcells}) = prompt_for_boshes_and_stemcells_for(!$pipeline{skip_upkeep}, %envs);
-
-	$pipeline{errands} = prompt_for_list("line",clean_heredoc(<<"	|EOF"), 'errand');
-	|Enter any errands you'd like to use to test your deployments
-	|e.g.: smoke-tests
-	|EOF
-
-	$pipeline{layouts} = prompt_for_layouts_for(%envs);
 
 	generate_ci_template_file(\%pipeline, $name);
 
@@ -4273,7 +4275,7 @@ sub prompt_for_locker {
 }
 
 sub prompt_for_vault {
-	my $name = shift;
+	my ($name, %envs) = @_;
 	explain "\n#Y{Vault Connection Details}";
 	my (%vault,$safe_json);
 	if (-f "$ENV{HOME}/.saferc") {
@@ -4292,12 +4294,84 @@ sub prompt_for_vault {
 		$vault{verify} = ! $safe_json->{SkipVerify}{$vault{url}};
 	}
 
-	$vault{role} = prompt_for_line(clean_heredoc(<<"	|EOF"),undef,"secret/$ENV{GENESIS_CI_VAULT_PREFIX}/$name/vault:role_id","vault_path");
-	|Please specify the path in Vault that contains the vault Role ID for Concourse
-	|EOF
-	$vault{secret} = prompt_for_line(clean_heredoc(<<"	|EOF"),undef,"secret/$ENV{GENESIS_CI_VAULT_PREFIX}/$name/vault:secret_id","vault_path");
-	|Please specify the path in Vault that contains the vault Secret ID for Concourse
-	|EOF
+	my $default_approle_path = "secret/$ENV{GENESIS_CI_VAULT_PREFIX}/$name/vault";
+	my ($regenerate, $c);
+
+	if (safe_path_exists $default_approle_path) {
+		my $choices = ["use","regen","alt"];
+		my $labels = [
+			"Use this path for role_id and secret_id",
+			"Regenerate new credentials to this path",
+			"Specify alternate paths for role_id and secret_id",
+		];
+		$c = prompt_for_choice(clean_heredoc(<<"		|EOF"),$choices,"use",$labels);
+		|Discovered Concourse AppRole credentials at $default_approle_path.
+		|Do you want to:
+		|EOF
+	} else {
+		my $choices = ["regen","alt"];
+		my $labels = [
+			"Generate credentials to this path",
+			"Specify alternate paths for role_id and secret_id",
+		];
+		$c = prompt_for_choice(clean_heredoc(<<"		|EOF"),$choices,"use",$labels);
+		|Could not find Concourse AppRole credentials at $default_approle_path.
+		|Do you want to:
+		|EOF
+	}
+	if ($c eq "use" || $c eq "regen") {
+		$regenerate = ($c eq "regen");
+		$vault{role}   = $default_approle_path . ":role_id";
+		$vault{secret} = $default_approle_path . ":secret_id";
+	} else {
+		$vault{role} = prompt_for_line(clean_heredoc(<<"		|EOF"),undef,"$default_approle_path:role_id","/secret\/.*[^\/]:.+", "Expecting secret/<path>:<key>");
+		|Please specify the path in Vault that contains the vault Role ID for Concourse
+		|EOF
+		$vault{secret} = prompt_for_line(clean_heredoc(<<"		|EOF"),undef,"$default_approle_path:secret_id",,"/secret\/.*[^\/]:.+", "Expecting secret/<path>:<key>");
+		|Please specify the path in Vault that contains the vault Secret ID for Concourse
+		|EOF
+
+		if (safe_path_exists $vault{role} && safe_path_exists $vault{secret}) {
+
+		} else {
+			explain "#R{WARNING: $vault{role} doesn't exist!" unless safe_path_exists $vault{role};
+			explain "#R{WARNING: $vault{secret} doesn't exist!" unless safe_path_exists $vault{secret};
+			die "Exiting.\n" unless prompt_for_boolean(clean_heredoc(<<"			|EOF"));
+			|To use these paths, the Concourse AppRole credentials will have to be (re-)generated.
+			|Continue [y|n]?
+			|EOF
+			$regenerate = 1;
+		}
+	}
+
+	if ($regenerate) {
+		my @paths;
+		foreach (keys %envs) {
+			my $env = $envs{$_}{env};
+			explain "#Y{Determining Vault paths needed for $env ...}\n";
+
+			my $dir = workdir;
+			if (is_create_env($env)) {
+				write_stemcell_data("$dir/cloud.yml"); # Why write stemcell to cloud.yml??!!
+			} else {
+				bosh_download_cloud_config(bosh_target_for($env), "$dir/cloud.yml");
+			}
+			my %options = ('cloud-config' => "$dir/cloud.yml");
+			my $vault_prefix = $envs{$_}{vault};
+			push @paths, "secret/$vault_prefix/*";
+			my @merge_files = @{merge_files($envs{$_}{file}, \%options)};
+			for my $extra_path (sort grep {chomp; $_ !~ m/^secret\/$vault_prefix\// } spruce_vault_paths(@merge_files)) {
+				push @paths, $extra_path;
+			}
+		}
+		push @paths, "secret/handshake";
+		generate_ci_approle_policies(
+			$name,
+			$vault{role},
+			$vault{secret},
+			@paths
+		)
+	};
 
 	return \%vault;
 }
@@ -4306,7 +4380,7 @@ sub prompt_for_boshes_and_stemcells_for {
 	my ($ask_stemcells, %envs) = @_;
 
 	# Get the current boshes
-	my %boshes;
+	my (%boshes, %chosen_envs);
 	if (-f $ENV{HOME}."/.bosh/config") {
 		my $bosh_json = decode_json(qx{spruce json \$HOME/.bosh/config});
 		$boshes{$_->{alias}} = {
@@ -4324,18 +4398,18 @@ sub prompt_for_boshes_and_stemcells_for {
 	foreach my $e (sort keys(%envs)) {
 		my $env = $envs{$e}{env};
 		explain "\n#W{==> Environment:} #C{$env} (./$envs{$e}{file})";
+		next unless prompt_for_boolean("Do you want to use this environment [y|n]?", 1);
+		$chosen_envs{$e} = $envs{$e};
+
 		$boshenvs{$env} = {};
 		my %bosh_info = %{$boshes{$envs{$e}{bosh}}};
-
-		next unless prompt_for_boolean("Do you want to use this environment [y|n]?", 1);
-
 		# Get display name (defaults to environment)
 		$boshenvs{$env}{alias} = prompt_for_line("Display name", undef, $env);
 
 		if (is_valid_uri($envs{$e}{bosh})) {
-			$boshenvs{$env}{url} = $envs{$e}{bosh}
+			$boshenvs{$env}{url} = $envs{$e}{bosh};
 		} else {
-			$boshenvs{$env}{url} = $bosh_info{url}
+			$boshenvs{$env}{url} = $bosh_info{url};
 		}
 		if ($boshenvs{$env}{url}) {
 			explain "\nUsing BOSH director at #C{$boshenvs{$env}{url}}";
@@ -4405,7 +4479,9 @@ sub prompt_for_boshes_and_stemcells_for {
 		print "\n";
 	}
 
-   return (\%boshenvs, \%used_stemcells);
+	die "NO REMAINING ENVIRONMENTS - Cannot continue!\n" unless %chosen_envs;
+
+	return (\%boshenvs, \%used_stemcells, %chosen_envs);
 }
 
 sub prompt_for_layouts_for {
@@ -5323,26 +5399,73 @@ sub {
 	generate_ci_hcl_file('-', @paths);
 });
 
+sub generate_ci_approle_policies {
+	my (
+		$role_name,
+		$role_path,
+		$secret_path,
+		@access_paths
+	) = @_;
+
+	my $dir = workdir;
+	my $hcl_file = "$dir/concourse.hcl";
+	my $r;
+
+	explain "#Y{Determining vault paths needed for Concourse pipelines...}\n";
+	generate_ci_hcl_file($hcl_file, @access_paths);
+
+	explain "#Y{Creating Concourse AppRole for $role_name}\n";
+	$r = system("safe", "vault", "policy-write", $role_name, $hcl_file);
+	die "Could not set policy for $role_name:\n$r\n" unless ($? >> 8) == 0;
+	$r = system("safe", "vault", "write", "auth/approle/role/$role_name",
+		"secret_id_ttl=0",
+		"token_num_uses=0",
+		"token_ttl=1m",
+		"token_max_ttl=1m",
+		"secret_id_num_uses=0",
+		"policies=$role_name"
+	);
+	die "Could not create approle for $role_name:\n$r\n" unless ($? >> 8) == 0;
+
+	explain "#Y{Getting role and secret credentials from AppRole}\n";
+	my ($role_p, $role_k) = $role_path =~/^(.*):([^:]*)$/;
+	die "Invalid vault path '$role_path': expecting <path>:<key>\n" unless defined($role_p) && defined($role_k);
+
+	my ($secret_p, $secret_k) = $secret_path =~/^(.*):([^:]*)$/;
+	die "Invalid vault path '$secret_path': expecting <path>:<key>\n" unless defined($secret_p) && defined($secret_k);
+
+	$r = qx(safe read auth/approle/role/$role_name/role-id | spruce json | jq -r .role_id | safe paste $role_p $role_k);
+	die "Could not store role_id to $role_path:\n$r\n" unless ($? >> 8) == 0;
+	$r = qx(safe vault write -f -format=json auth/approle/role/$role_name/secret-id | jq -r '.data.secret_id' | safe paste $secret_p $secret_k);
+	die "Could not store secret_id to $secret_path:\n$r\n" unless ($? >> 8) == 0;
+
+	explain "#G{Completed AppRole creation for $role_name.}";
+}
+
 sub generate_ci_hcl_file {
 	my (
 		$hclfile,           # SET TO '-' to print to screen
 		@vault_paths
 	) = @_;
 
-	my $fh = *STDOUT;
-	unless ($hclfile eq '-') {
+	my $fh;
+	if ($hclfile eq '-') {
+		$fh = *STDOUT;
+	} else {
 		open($fh, ">$hclfile") or die "can't open $hclfile: $!\n";
 	}
 
+	my %done;
 	foreach (@vault_paths) {
+		next if $done{$_};
+		$done{$_} = 1;
 		print $fh clean_heredoc(<<"		|EOF");
 		|path "$_" {
 		|    capabilities = [ "read", "list" ]
 		|}
-		|
 		|EOF
 	}
-	close $fh unless $hclfile eq '-';
+	close $fh unless ($hclfile eq '-');
 }
 
 # }}}

--- a/bin/genesis
+++ b/bin/genesis
@@ -1281,7 +1281,7 @@ sub deploy_manifest {
 	$ENV{REDACT} = '';
 	my $dir = workdir;
 	my $target = ''; 
-	my $create_env = has_subkit($env, 'bosh-init') || has_subkit($env, 'create-env');
+	my $create_env = is_create_env($env);
 
 	if (!$create_env) {
 		$target = bosh_target_for($env);
@@ -5295,7 +5295,6 @@ sub {
 	$ENV{REDACT} = "true"; # we don't need vault creds for this, just pipeline layout
 	my $pipeline = parse_pipeline($options{config}, $layout);
 	for my $env (sort @{$pipeline->{envs}}) {
-		my $create_env = is_create_env($env);
 		# Always grab cloud config, since we're probably up and running if using this command
 		# Posible issues we could run into are that the jumpbox doesn't have access to all
 		# BOSH directors, or that someone is trying to build their vault policies before
@@ -5303,10 +5302,10 @@ sub {
 		# somehow providing cloud configs for *all* boshes, or by making `spruce vaultinfo`
 		# ignore static_ips?
 		my $dir = workdir;
-		if (!$create_env) {
-			bosh_download_cloud_config(bosh_target_for($env), "$dir/cloud.yml");
-		} else {
+		if (is_create_env($env)) {
 			write_stemcell_data("$dir/cloud.yml"); # Why write stemcell to cloud.yml??!!
+		} else {
+			bosh_download_cloud_config(bosh_target_for($env), "$dir/cloud.yml");
 		}
 		$options{'cloud-config'} = "$dir/cloud.yml";
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -4384,6 +4384,7 @@ sub prompt_for_boshes_and_stemcells_for {
 	if (-f $ENV{HOME}."/.bosh/config") {
 		my $bosh_json = decode_json(qx{spruce json \$HOME/.bosh/config});
 		$boshes{$_->{alias}} = {
+			#url => (($_->{url} =~ /:\d+$/) ? $_->{url} : $_->{url}.":25555"),
 			url => $_->{url},
 			username => $_->{username},
 			password => $_->{password},
@@ -4410,11 +4411,13 @@ sub prompt_for_boshes_and_stemcells_for {
 			$boshenvs{$env}{url} = $envs{$e}{bosh};
 		} else {
 			$boshenvs{$env}{url} = $bosh_info{url};
+			$boshenvs{$env}{url} .= ":25555" unless $boshenvs{$env}{url} =~ m/:\d+$/;
 		}
 		if ($boshenvs{$env}{url}) {
 			explain "\nUsing BOSH director at #C{$boshenvs{$env}{url}}";
 		} else {
 			$boshenvs{$env}{url} = prompt_for_line("Could not determine BOSH url -- please specify fully\ne.g.: https://10.0.1.44:25555");
+			$boshenvs{$env}{url} .= ":25555" unless $boshenvs{$env}{url} =~ m/:\d+$/;
 		}
 
 		if ($bosh_info{username}) {

--- a/bin/genesis
+++ b/bin/genesis
@@ -5290,6 +5290,7 @@ sub {
 
 	my $layout = $_[0] || "default";
 	$options{config} ||= "ci.yml";
+	my @paths;
 
 	$ENV{REDACT} = "true"; # we don't need vault creds for this, just pipeline layout
 	my $pipeline = parse_pipeline($options{config}, $layout);
@@ -5305,36 +5306,46 @@ sub {
 		if (!$create_env) {
 			bosh_download_cloud_config(bosh_target_for($env), "$dir/cloud.yml");
 		} else {
-			write_stemcell_data("$dir/cloud.yml");
+			write_stemcell_data("$dir/cloud.yml"); # Why write stemcell to cloud.yml??!!
 		}
 		$options{'cloud-config'} = "$dir/cloud.yml";
 
 		# get all files for a deployment
 		my $vault_prefix = get_key($env, "params.vault", "");
 		chomp $vault_prefix;
-		$vault_prefix = "secret/$vault_prefix";
 		die "Unable to find `params.vault' for environment `$env'. Cannot continue\n" unless $vault_prefix;
-		print <<EOF;
-path "$vault_prefix/*" {
-    capabilities = [ "read", "list" ]
-}
 
-EOF
-		for my $path (sort grep { chomp; $_ !~ m/^$vault_prefix/ } spruce_vault_paths(@{merge_files($env, \%options)})) {
-			print <<EOF;
-path "$path" {
-    capabilities = [ "read", "list" ]
-}
-
-EOF
+		push @paths, "secret/$vault_prefix/*";
+		for my $extra_path (sort grep {chomp; $_ !~ m/^secret\/$vault_prefix\// } spruce_vault_paths(@{merge_files($env, \%options)})) {
+			push @paths, $extra_path;
 		}
 	}
-	print <<EOF;
-path "secret/handshake" {
-    capabilities = [ "read", "list" ]
-}
-EOF
+	push @paths, "secret/handshake";
+	generate_ci_hcl_file('-', @paths);
 });
+
+sub generate_ci_hcl_file {
+	my (
+		$hclfile,           # SET TO '-' to print to screen
+		@vault_paths
+	) = @_;
+
+	my $fh = *STDOUT;
+	unless ($hclfile eq '-') {
+		open($fh, ">$hclfile") or die "can't open $hclfile: $!\n";
+	}
+
+	foreach (@vault_paths) {
+		print $fh clean_heredoc(<<"		|EOF");
+		|path "$_" {
+		|    capabilities = [ "read", "list" ]
+		|}
+		|
+		|EOF
+	}
+	close $fh unless $hclfile eq '-';
+}
+
 # }}}
 # genesis ci-pipeline-deploy - Deploy via the CI/CD Pipeline {{{
 

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,14 @@
+# Improvements:
+
+* Added ability to generate vault policies for Concourse pipelines as part of
+  the `genesis ci` wizard.
+
+* Allows user to select to not add specific environments to the pipeline in
+  the `genesis ci` wizard.
+
+* Added ability to echo vault-stored parameters in `genesis new`.
+
+# Bug Fixes:
+
+* When generating ci.yml, the `genesis ci` wizard defaults to port 25555 for
+  BOSH director URLs when no port is provided by the local BOSH config.

--- a/t/compiling.t
+++ b/t/compiling.t
@@ -22,7 +22,6 @@ if ($bsdtar) {
 $repo = "compile-test-deployments-bad";
 ok -d "t/repos/$repo", "$repo repo exists" or die;
 chdir "t/repos/$repo" or die;
-diag "Running in t/repos/$repo";
 qx(rm -f *.tar.gz *.tgz); # just to be safe
 
 ($pass, $rc, $msg) = run_fails "genesis compile-kit --name custom-named-kit --version 1.0.4 --dev", 2;
@@ -56,7 +55,6 @@ chdir "../../.." or die;
 $repo = "compile-test-deployments";
 ok -d "t/repos/$repo", "$repo repo exists" or die;
 chdir "t/repos/$repo" or die;
-diag "Running in t/repos/$repo";
 qx(rm -f *.tar.gz *.tgz); # just to be safe
 
 ($pass, $rc, $msg) = runs_ok "genesis compile-kit --version 1.0.4";
@@ -83,7 +81,6 @@ chdir "../../.." or die;
 $repo = "compile-test-genesis-kit-bad";
 ok -d "t/repos/$repo", "$repo repo exists" or die;
 chdir "t/repos/$repo" or die;
-diag "Running in t/repos/$repo";
 qx(rm -f *.tar.gz *.tgz); # just to be safe
 
 ($pass, $rc, $msg) = run_fails "genesis compile-kit --name my-kit --version 1.0.4", 2;
@@ -105,7 +102,6 @@ chdir "../../.." or die;
 $repo = "compile-test-genesis-kit";
 ok -d "t/repos/$repo", "$repo repo exists" or die;
 chdir "t/repos/$repo" or die;
-diag "Running in t/repos/$repo";
 qx(rm -f *.tar.gz *.tgz); # just to be safe
 
 # Try to run it in dev mode


### PR DESCRIPTION
# Improvements:

* Added ability to generate vault policies for Concourse pipelines as part of the `genesis ci` wizard.

* Allows user to select to not add specific environments to the pipeline in the `genesis ci` wizard.

# Bug Fixes:

* When generating ci.yml, the `genesis ci` wizard defaults to port 25555 for BOSH director URLs when no port is provided by the local BOSH config.