### PR TITLE
Enforce hierarchial naming of environments to promote pipelines, create top-level env file.

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -168,6 +168,15 @@ sub trace(@) {
 	print STDERR "\n";
 }
 
+sub same($$) {
+	my ($a,$b) = @_;
+	die "Arguments are not arrays" unless ref($a) eq 'ARRAY' && ref($b) eq 'ARRAY';
+	return 0 unless scalar(@$a) == scalar(@$b);
+	return 0 unless join(',',map {length} @$a) eq join(',',map {length} @$b);
+	return 0 unless join("\0", @$a) eq join("\0",@$b);
+	return 1;
+}
+
 sub error {
 	my @err = @_;
 	unshift @err, "%s" if $#err == 0;
@@ -405,22 +414,57 @@ sub new_environment {
 	$version = "latest" unless defined $version;
 
 	my $file = "$env.yml";
-	open my $fh, ">", $file or die "Couldn't write to $file: $!";
-	print $fh <<EOF;
+	(my $parent = $file) =~ s/-.*\.yml/.yml/;
+
+	my %existing_info;
+	if (-e $parent) {
+		%existing_info = %{LoadFile($parent)};
+		explain "Using #C{$parent} file as base config.";
+	} else {
+		open my $fh, ">", $parent or die "Couldn't write to $parent: $!";
+		print $fh <<EOF;
 ---
 kit:
   name:    $kit
   version: $version
 EOF
-	if (! @subkits) {
-		print $fh "  subkits: []\n";
-	} else {
-		print $fh "  subkits:\n";
-		for my $subkit (@subkits) {
-			print $fh <<EOF;
-  - $subkit
-EOF
+		if (@subkits) {
+			print $fh "  subkits:\n";
+			print $fh "  - $_\n" foreach (@subkits);
+		} else {
+			print $fh "  subkits: []\n";
 		}
+		%existing_info = (
+			kit => {
+				name => $kit,
+				version => $version,
+				subkits => \@subkits
+			}
+		);
+		close $fh; $fh = undef;
+		explain "Created #C{$parent} file for $kit/$version";
+	}
+
+	open my $fh, ">", $file or die "Couldn't write to $file: $!";
+	print $fh "---";
+	print $fh "\nkit:\n" if (
+		!%existing_info ||
+		$existing_info{kit}{name} ne $kit ||
+		$existing_info{kit}{version} ne $version ||
+		!same($existing_info{kit}{subkits}||[],\@subkits)
+	);
+	if (!%existing_info || $existing_info{kit}{name} ne $kit) {
+		print $fh "  name:    $kit\n";
+		error "#y{WARNING:} $parent specifies a different kit name ($existing_info{kit}{name})";
+	}
+	if (!%existing_info || $existing_info{kit}{version} ne $version) {
+		print $fh "  version: $version\n";
+		error "#y{WARNING:} $parent specifies a different kit version ($existing_info{kit}{version})";
+	}
+	if (!%existing_info || !same($existing_info{kit}{subkits}||[],\@subkits)) {
+		print $fh "  subkits:\n";
+		print $fh "  - (( replace ))\n" if defined($existing_info{kit}{subkits});
+		print $fh "  - $_\n" foreach (@subkits);
 	}
 	print $fh <<EOF;
 
@@ -479,6 +523,7 @@ EOF
 		}
 	}
 	close $fh;
+	explain "Created #C{$file} environment file";
 }
 
 sub kit_yaml_files_in {
@@ -817,10 +862,13 @@ sub validate_repo_name {
 	return $name =~ m/^[a-z][a-z0-9-]+$/;
 }
 
-sub validate_env_name {
+sub check_env_name_for_errors {
 	my ($name) = @_;
-	return $name =~ m/^[a-z][a-z0-9-]+$/
-	    && $name !~ m/--/;
+	return "Can only contain lowercase alphanumeric characters and dashes." if $name !~ m/^[a-z0-9-]+$/;
+	return "Must start with a lowercase alphabetic character." if $name !~ m/^[a-z]/;
+	return "Cannot contain sequential dashes." if $name =~ m/--/;
+	return "Must be at least two levels to allow a base file for pipeline propagation." if $name !~ m/-/;
+	return "";
 }
 
 ###########################################################################
@@ -3961,7 +4009,8 @@ sub {
 	my ($name) = @_;
 	$name =~ s/\.ya?ml$//;
 
-	validate_env_name $name or die "Invalid environment name '$name'\n";
+	my $err = check_env_name_for_errors($name);
+	die "Invalid environment name '$name': $err\n" if $err;
 	-f "$name.yml" and die "Environment '$name' already exists\n";
 
 	at_exit(sub {
@@ -4464,7 +4513,6 @@ sub prompt_for_boshes_and_stemcells_for {
 			|EOF
 		}
 
-		
 		my ($stemcells, %candidates) = ([]);
 		if ($ask_stemcells) {
 			explain "\nFetching stemcells from BOSH...";
@@ -4477,7 +4525,7 @@ sub prompt_for_boshes_and_stemcells_for {
 				foreach (split("\n", $sc_info)) {
 					my ($stemcell, undef, $os) = split(' ',  $_);
 					next unless $stemcell;
-					
+
 					my ($alias) = split("-$os-",$stemcell);
 					$alias =~ s/^bosh-//;
 					$alias .= '-$os' if $candidates{$alias} &&($candidates{$alias} ne $stemcell);

--- a/t/compiled.t
+++ b/t/compiled.t
@@ -29,17 +29,19 @@ EOF
 
 qx(rm -f new-env.yml);
 runs_ok "genesis new --no-secrets new-env";
-is get_file("new-env.yml"), <<EOF, "environment file generated has latest kit name / version in it";
+is get_file("new.yml"), <<EOF, "environment file generated has latest kit name / version in it";
 ---
 kit:
   name:    compiled
   version: 0.0.2
   subkits: []
-
+EOF
+is get_file("new-env.yml"), <<EOF, "environment file generated doesn't have kit name / version in it";
+---
 params:
   env:   new-env
   vault: new/env/compiled-kit-test
 EOF
-qx(rm -f new-env.yml);
+qx(rm -f new.yml new-env.yml);
 
 done_testing;

--- a/t/expect/simple-omega
+++ b/t/expect/simple-omega
@@ -1,0 +1,53 @@
+#!/usr/bin/expect
+
+#log_user 0
+spawn /bin/sh -c "exec 2>&1 ; genesis --no-color new [set argv]"
+
+set step "waiting for the question about authentication"
+expect {
+  "*How would you like to perform authentication?\r\n\r\n" { }
+  timeout { puts "Timed out [set step]\n"      ; exit 1 }
+  eof     { puts "Unexpected EOF [set step]\n" ; exit 1 }
+}
+
+set step "looking for authentication choice prompt"
+expect {
+  "*\r\n choice? \\\[1-3]: " {
+    send "3\r" ;# choose cf-uaa
+  }
+  timeout { puts "Timed out [set step]\n"      ; exit 1 }
+  eof     { puts "Unexpected EOF [set step]\n" ; exit 1 }
+}
+
+set step "waiting for the question about toolbelt"
+expect {
+  "*Would you like to load the most excellent Toolbelt add-on?\r\n\\\[Y/n]: " {
+    send "no\r" ;# choose toolbelt
+  }
+  timeout { puts "Timed out [set step]\n"      ; exit 1 }
+  eof     { puts "Unexpected EOF [set step]\n" ; exit 1 }
+}
+
+set step "waiting for the question about backups"
+expect {
+  "*How would you like to perform backups of this deployment?\r\n" { }
+  timeout { puts "Timed out [set step]\n"      ; exit 1 }
+  eof     { puts "Unexpected EOF [set step]\n" ; exit 1 }
+}
+
+set step "looking for backups choice prompt"
+expect {
+  "*\r\n choice? \\\[1-3]: " {
+    send "3\r" ;# choose shield
+  }
+  timeout { puts "Timed out [set step]\n"      ; exit 1 }
+  eof     { puts "Unexpected EOF [set step]\n" ; exit 1 }
+}
+
+set timeout 60 ;# in case we are vaulting
+set step "waiting for success indicator"
+expect {
+  "*New environment [lindex $argv 0] provisioned.\r\n" { }
+  timeout { puts "Timed out [set step]\n"      ; exit 1 }
+  eof     { puts "Unexpected EOF [set step]\n" ; exit 1 }
+}

--- a/t/new.t
+++ b/t/new.t
@@ -37,5 +37,94 @@ no_env "a--b";
 run_fails "genesis new a--b",   "`genesis new` doesn't allow multi-dash environment names";
 no_env "a--b";
 
+no_env "basename";
+my ($rc,$exit,$msg) = run_fails "genesis new basename", 2, "`genesis new` does not allow unhyphenated environments";
+matches $msg, qr/Must be at least two levels to allow a base file for pipeline propagation\./, "`genesis new` gives error when unhyphenated env name given";
+no_env "basename";
+
+# Test base file propagation
+no_env "generate";
+no_env "generate-nominal";
+expects_ok "simple-omega generate-nominal --no-secrets";
+have_env 'generate';
+have_env 'generate-nominal';
+is get_file("generate.yml"), <<EOF, "environment file generated has latest kit name / version in it";
+---
+kit:
+  name:    dev
+  version: latest
+  subkits:
+  - basic
+EOF
+is get_file("generate-nominal.yml"), <<EOF, "environment file generated has latest kit name / version in it";
+---
+params:
+  env:   generate-nominal
+  vault: generate/nominal/omega
+EOF
+
+no_env "generate-full";
+expects_ok "new-omega generate-full --no-secrets";
+have_env 'generate';
+have_env 'generate-full';
+is get_file("generate.yml"), <<EOF, "environment file generated has latest kit name / version in it";
+---
+kit:
+  name:    dev
+  version: latest
+  subkits:
+  - basic
+EOF
+is get_file("generate-full.yml"), <<EOF, "environment file generated has latest kit name / version in it";
+---
+kit:
+  subkits:
+  - (( replace ))
+  - cf-uaa
+  - toolbelt
+  - shield
+
+params:
+  env:   generate-full
+  vault: generate/full/omega
+EOF
+
+open my $fh, ">", "generate.yml" or die "Could not overwrite generate.yml\n";
+print $fh <<EOF;
+---
+kit:
+  name:    omega
+  version: 0.1.2
+  subkits:
+  - cf-uaa
+  - toolbelt
+  - shield
+EOF
+close $fh;
+
+expects_ok "new-omega generate-full-2 --no-secrets";
+have_env 'generate';
+have_env 'generate-full-2';
+is get_file("generate.yml"), <<EOF, "environment file generated has latest kit name / version in it";
+---
+kit:
+  name:    omega
+  version: 0.1.2
+  subkits:
+  - cf-uaa
+  - toolbelt
+  - shield
+EOF
+is get_file("generate-full-2.yml"), <<EOF, "environment file generated has latest kit name / version in it";
+---
+kit:
+  name:    dev
+  version: latest
+
+params:
+  env:   generate-full-2
+  vault: generate/full/2/omega
+EOF
+
 chdir $TOPDIR;
 done_testing;

--- a/t/param-asking.t
+++ b/t/param-asking.t
@@ -386,14 +386,17 @@ expect_ok "Finished, --no-secrets option", $cmd, [
 ];
 
 expect_exit $cmd, 0, "Creating a new environment with subkits exited successfully";
-eq_or_diff get_file("with-subkit.yml"), <<EOF, "New environment file contains base + subkit params, comments, and examples";
+eq_or_diff get_file("with.yml"), <<EOF, "New environment file contains base + subkit params, comments, and examples";
 ---
 kit:
   name:    dev
   version: latest
   subkits:
   - subkit-params
+EOF
 
+eq_or_diff get_file("with-subkit.yml"), <<EOF, "New environment file contains base + subkit params, comments, and examples";
+---
 params:
   env:   with-subkit
   vault: with/subkit/ask-params
@@ -544,13 +547,16 @@ expect_ok "getting second user", $cmd, ['2nd user >', sub {
 expect_ok "getting third user", $cmd, ['3rd user >', sub {
 		$_[0]->send("\n"); }];
 expect_exit $cmd, 0, "Creating a new environment without subkits exited successfully";
-eq_or_diff get_file("without-subkit.yml"), <<EOF, "New environment file contains base params, comments, and examples (no subkits)";
+eq_or_diff get_file("without.yml"), <<EOF, "New environment file contains base params, comments, and examples (no subkits)";
 ---
 kit:
   name:    dev
   version: latest
   subkits: []
+EOF
 
+eq_or_diff get_file("without-subkit.yml"), <<EOF, "New environment file contains base params, comments, and examples (no subkits)";
+---
 params:
   env:   without-subkit
   vault: without/subkit/ask-params


### PR DESCRIPTION
Genesis provides pipelines to propagate changes through CI phases, but by default, there is no innately shared values between the different environments.  Or is there...?

The environment files are actually based on a hierarchical structure using dashes to separate the files.  This means that corp-zone-env.yml env file actually inherits from corp.yml and corp-zone.yml, if they exist.  Furthermore, these ancestral files propagate through the pipeline, so they need to pass previous tasks before they get to later tasks.  What does this mean?  It means that if you increment the kit version in corp.yml, then it has to pass corp-dev before it gets applied to corp-prod (assuming that's how you configured your pipeline)

To this end, this PR does two things:  It automatically creates the top-level file, containing the kit name, version and subkits, and second, it doesn't let you create flat envs (env names that don't contain a dash) to promote awareness and usage of these hierarchies.

Fixes #188, though not in the way it was described.