### PR TITLE
`genesis repipe`: does not create unused stemcell locks

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -2227,7 +2227,8 @@ EOF
 				# times - not necessary for create-env
 				# <alias>-bosh-lock is used to prevent the parent bosh from upgrading while we deploy
 				# - not necessary for create-env
-				print $OUT <<EOF;
+				unless ($pipeline->{pipeline}{skip_upkeep}) {
+					print $OUT <<EOF;
   - name: ${alias}-stemcell-lock
     type: locker
     source:
@@ -2238,6 +2239,9 @@ EOF
       ca_cert: (( grab pipeline.locker.ca_cert ))
       lock_name: ${bosh_lock}-stemcell-lock
 
+EOF
+				}
+				print $OUT <<EOF;
   - name: ${alias}-bosh-lock
     type: locker
     source:

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Bug Fix
+
+* `genesis repipe` no longer fails when using locker without keeping stemcells up-to-date


### PR DESCRIPTION
If stemcell updates are disabled, but locker is enabled, it would create stemcell-locks but not use them.  This has been rectified.

Fixes #184