### PR TITLE
Added minimal genesis version spec for kits

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -2847,6 +2847,10 @@ sub generate_pipeline_human_description {
 	}
 }
 
+sub is_semver {
+	return $_[0] =~ m/^(\d+)(?:\.(\d+)(?:\.(\d+)(?:[.-]rc[.-]?(\d+))?)?)?$/;
+}
+
 sub semver {
 	my ($name, $v) = @_;
 	if ($v =~  m/^(\d+)(?:\.(\d+)(?:\.(\d+)(?:[.-]rc[.-]?(\d+))?)?)?$/) {
@@ -3063,10 +3067,28 @@ sub validate_kit_files {
 }
 
 sub validate_kit_metadata {
-	my ($kit, $version, $meta,$is_author) = @_;
+	my ($kit, $version, $meta, $is_author) = @_;
 	$kit ||= "dev";
 	$version = "latest" unless defined $version;
 	my @errors;
+
+	# Validate acceptable genesis version
+	if (defined $meta->{genesis_version_min}) {
+		if (!is_semver $meta->{genesis_version_min}) {
+			push @errors, "Specified minimum Genesis version of '$meta->{genesis_version_min}' for kit is invalid.";
+		} elsif (!is_semver $VERSION) {
+			error "#Y{WARNING:} Using a development version of Genesis.  Cannot determine if minimal Genesis version of '$meta->{genesis_version_min}' by kit '$kit/$version' is met."
+		} elsif (! new_enough "genesis", $VERSION, $meta->{genesis_version_min}) {
+			# Fatal error - die immediately
+			error clean_heredoc(<<"			|EOF");
+			|#R{ERROR:} Kit $kit/$version requires Genesis version $meta->{genesis_version_min}, but installed Genesis is only version $VERSION.
+			|
+			|Please upgrade your version and don't forget to run `genesis embed` to update the version embedded in your deployment repository.
+			|
+			|EOF
+			exit 86; #no longer available, decommissioned, off the menu
+		}
+	}
 
 	# validate params
 	for my $subkit (sort keys %{$meta->{params}}) {
@@ -3171,9 +3193,9 @@ sub validate_kit_metadata {
 	}
 
 	if (@errors) {
-		print STDERR "The following errors have been encountered validating the $kit/$version kit:\n";
+		error "#R{ERROR:} The following errors have been encountered validating the $kit/$version kit:\n";
 		for my $err (@errors) {
-			print STDERR " - $err\n";
+			error " - $err\n";
 		}
 		die ($is_author ? "Cannot continue.\n" : "Please contact your kit author for a fix.\n");
 	}
@@ -3221,11 +3243,12 @@ sub kit_name_and_version_for {
 
 sub check_kit_prereqs {
 	my ($kit, $version) = @_;
-	my $script = kit_file($kit, $version, "prereqs", 0);
+	my $script = kit_file($kit, $version, "hooks/prereqs", 0);
 	return unless -e $script;
-	-x $script or die "Prereqs script $script was found, but is not executable...\n";
-	qx(./dev/prereqs);
-	$? == 0 or die "Some prerequisites for this Genesis Kit have not been met.\n";
+	explain "Checking kit pre-requisites...\n";
+	-x $script || chmod_or_fail 0755, $script;
+	my $out = qx($script);
+	$? == 0 or die "Some prerequisites for this Genesis Kit have not been met:\n$out\n";
 }
 
 sub prompt_for_subkits_alternates {
@@ -4052,8 +4075,6 @@ sub {
 	}
 
 	my $meta = read_kit_metadata($kit, $version);
-
-	explain "Checking kit pre-requisites...\n";
 	check_kit_prereqs($kit, $version);
 
 	my @subkits = prompt_for_subkits($meta->{subkits} || []);
@@ -5006,15 +5027,23 @@ EOF
 		$subkits = "subkits: []\n";
 	}
 
+	my $gen_version="";
+	if (is_semver $VERSION) {
+		$gen_version = "\ngenesis_min_version: $VERSION\n";
+	} else {
+		print STDERR csprintf("\n#R{Warning:} Using development version of Genesis -- cannot specify minimum Genesis version\n");
+	}
+
 	chomp(my $user = qx'git config user.name');
 	chomp(my $email = qx'git config user.email');
 	mkfile_or_fail "$dir/kit.yml", <<EOF;
 ---
 name: $options{name}
+version: 0.0.1
 author: $user <$email>
 homepage: https://github.com/cloudfoundry-community/$options{name}-boshrelease
 github: https://github.com/genesis-community/$options{name}-genesis-kit
-
+$gen_version
 $subkits
 params:
   base: []

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,3 +1,11 @@
+# New Feature
+
+* In anticipation for new features in Genesis that kits may rely on, Genesis
+  now allows kits to specify the minimum version of Genesis that they can be
+  used on.  Specify `genesis_version_min` to a semver value in your kit.yml to
+  make use of this.  By default, creating a new kit with `genesis create-kit`
+  will set this to your current version of Genesis.
+
 # Bug Fix
 
 * `genesis repipe` no longer fails when using locker without keeping stemcells up-to-date

--- a/t/helper.pm
+++ b/t/helper.pm
@@ -62,6 +62,21 @@ sub spruce_fmt($$) {
 	close $fh;
 }
 
+sub compiled_genesis {
+  my ($version) = @_;
+  my ($rc, $out);
+  my $tmp = workdir();
+
+  my $cmd = "cd $TOPDIR && GENESIS_PACK_PATH=$tmp ./pack";
+  $cmd .= " $version" if $version;
+  $out = qx($cmd 2>&1);
+  $rc = $? >> 8;
+  die "Could not compile genesis: $!" if $? >> 8;
+  die "Could not compile genesis: $out" unless $out =~ qr%packaged v${\($version || "2.x.x")}%;
+  (my $bin = $out) =~ s/\A.* as (.*\/genesis[^\s]*).*\z/$1/sm;
+  return Cwd::abs_path($bin);
+}
+
 sub reprovision {
 	my %opts = @_;
 	my $err = qx(rm -rf *.yml .genesis/kits .genesis/cache dev/);

--- a/t/kits/prereqs/hooks/prereqs
+++ b/t/kits/prereqs/hooks/prereqs
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# The point of this script is to exit 0 if all
+# required bits of functionality are present on
+# the system - i.e. version checks, OS capabilities,
+# (internet connectivity?)
+#
+# However, since this is a test, we're going to
+# conditionally exit 0/non-zero based on the env var
+# `$SHOULD_FAIL`.  ¯\_(ツ)_/¯
+
+set -e
+test -z "$SHOULD_FAIL"

--- a/t/kits/version-prereq-bad/hooks/prereqs
+++ b/t/kits/version-prereq-bad/hooks/prereqs
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# The point of this script is to exit 0 if all
+# required bits of functionality are present on
+# the system - i.e. version checks, OS capabilities,
+# (internet connectivity?)
+#
+# However, since this is a test, we're going to
+# conditionally exit 0/non-zero based on the env var
+# `$SHOULD_FAIL`.  ¯\_(ツ)_/¯
+
+set -e
+test -z "$SHOULD_FAIL"

--- a/t/kits/version-prereq-bad/kit.yml
+++ b/t/kits/version-prereq-bad/kit.yml
@@ -1,0 +1,4 @@
+name: Kit Dependencies Test
+version: 0.0.1
+
+genesis_version_min: "~>4.5"

--- a/t/kits/version-prereq/hooks/prereqs
+++ b/t/kits/version-prereq/hooks/prereqs
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# The point of this script is to exit 0 if all
+# required bits of functionality are present on
+# the system - i.e. version checks, OS capabilities,
+# (internet connectivity?)
+#
+# However, since this is a test, we're going to
+# conditionally exit 0/non-zero based on the env var
+# `$SHOULD_FAIL`.  ¯\_(ツ)_/¯
+
+set -e
+test -z "$SHOULD_FAIL"

--- a/t/kits/version-prereq/kit.yml
+++ b/t/kits/version-prereq/kit.yml
@@ -1,0 +1,4 @@
+name: Kit Dependencies Test
+version: 0.0.1
+
+genesis_version_min: 9.5.2

--- a/t/prereqs.t
+++ b/t/prereqs.t
@@ -4,13 +4,18 @@ use warnings;
 
 use lib 't';
 use helper;
+use Expect;
+use Cwd qw(abs_path);
+
+# EXPECT DEBUGGING
+my $log_expect_stdout=0;
 
 my $dir = workdir;
 chdir $dir;
 
-
 bosh2_cli_ok;
 
+my ($pass, $rc, $msg);
 reprovision kit => 'prereqs';
 
 $ENV{SHOULD_FAIL} = '';
@@ -20,5 +25,46 @@ ok -f "successful-env.yml", "Environment file should be created, when prereqs pa
 $ENV{SHOULD_FAIL} = 'yes';
 run_fails "genesis new failed-env --no-secrets", 1;
 ok ! -f "failed-env.yml", "Environment file should not be created, when prereqs fails";
+
+$ENV{SHOULD_FAIL} = '';
+reprovision kit =>'version-prereq', compiled => 1;
+($pass, $rc, $msg) = runs_ok "genesis new using-dev-genesis --no-secrets ";
+matches $msg, qr%.*WARNING.* Using a development version of Genesis.  Cannot determine if minimal Genesis version of '9.5.2' by kit 'version-prereq/1.0.0' is met.%,"Genesis dev version";
+matches $msg, qr'New environment using-dev-genesis provisioned.', "Created new environment 'using-dev-genesis'";
+ok -f "using.yml", "Org environment file should not be created, when prereqs fails";
+ok -f "using-dev-genesis.yml", "Deployment environment file should not be created, when prereqs fails";
+
+my $bin = compiled_genesis "9.0.1";
+
+($pass, $rc, $msg) = run_fails "$bin new something-new", 86;
+matches $msg, qr'.*ERROR:.* Kit version-prereq/1.0.0 requires Genesis version 9.5.2, but installed Genesis is only version 9.0.1.',"Genesis not new enough";
+doesnt_match $msg, qr'New environment something-new provisioned.', "Did not create new environment 'something-new'";
+ok ! -f "something.yml", "Org environment file should not be created, when prereqs fails";
+ok ! -f "something-new.yml", "Deployment environment file should not be created, when prereqs fails";
+
+$bin = compiled_genesis "9.5.2";
+($pass, $rc, $msg) = runs_ok "$bin new something-new --no-secrets";
+doesnt_match $msg, qr'.*ERROR:.* Kit version-prereq/1.0.0 requires Genesis version 9.5.2, but installed Genesis is only version 9.5.2.',"Genesis should be new enough";
+matches $msg, qr'New environment something-new provisioned.', "Created new environment 'something-new'";
+ok -f "something.yml", "Org environment file should be created, when version meets minimum ";
+ok -f "something-new.yml", "Deployment environment file should be created, when version meets minimum";
+
+$bin = compiled_genesis "10.0.0-rc56";
+($pass, $rc, $msg) = runs_ok "$bin new something-newer --no-secrets";
+doesnt_match $msg, qr'.*ERROR:.* Kit version-prereq/1.0.0 requires Genesis version 9.5.2, but installed Genesis is only version 10.0.0-r56.',"Genesis should be new enough";
+matches $msg, qr'New environment something-newer provisioned.', "Created new environment 'something-new'";
+ok -f "something.yml", "Org environment file should be created, when version meets minimum ";
+ok -f "something-newer.yml", "Deployment environment file should be created, when version meets minimum";
+
+reprovision kit =>'version-prereq-bad';
+($pass, $rc, $msg) = run_fails "$bin new something-crazy", 255;
+
+#
+matches $msg, qr'.*ERROR:.* The following errors have been encountered validating the dev/latest kit:',"kit has errors";
+matches $msg, qr% - Specified minimum Genesis version of '~>4.5' for kit is invalid.%,"kit has bad min version";
+matches $msg, qr'Please contact your kit author for a fix.',"kit has bad min version - cannot continue ";
+doesnt_match $msg, qr'New environment something-crazy provisioned.', "Did not create new environment 'something-crazy'";
+ok ! -f "something.yml", "Org-level env file should not exist.";
+ok ! -f "something-crazy.yml", "Deployment environment file should not be created, when kit min genesis version bad";
 
 done_testing;


### PR DESCRIPTION
In anticipation for new features in Genesis that kits may rely on, Genesis now allows kits to specify the minimum version of Genesis that they can be used on.  Specify `genesis_version_min` to a semver value in your kit.yml to make use of this.  By default, creating a new kit with `genesis create-kit` will set this to your current version of Genesis.