### PR TITLE
Blueprints and new hooks

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -428,35 +428,7 @@ sub new_environment {
 
 	my $file = "$env.yml";
 	(my $parent = $file) =~ s/-.*\.yml/.yml/;
-
-	my %existing_info;
-	if (-e $parent) {
-		%existing_info = %{LoadFile($parent)};
-		explain "Using #C{$parent} file as base config.";
-	} else {
-		open my $fh, ">", $parent or die "Couldn't write to $parent: $!";
-		print $fh <<EOF;
----
-kit:
-  name:     $kit
-  version:  $version
-EOF
-		if (@features) {
-			print $fh "  features:\n";
-			print $fh "  - $_\n" foreach (@features);
-		} else {
-			print $fh "  features: []\n";
-		}
-		%existing_info = (
-			kit => {
-				name => $kit,
-				version => $version,
-				features => \@features
-			}
-		);
-		close $fh; $fh = undef;
-		explain "Created #C{$parent} file for $kit/$version";
-	}
+	my %existing_info = ensure_org_level_environment_file_exists($parent,$kit,$version,@features);
 
 	open my $fh, ">", $file or die "Couldn't write to $file: $!";
 	print $fh "---";
@@ -537,6 +509,40 @@ EOF
 	}
 	close $fh;
 	explain "Created #C{$file} environment file";
+}
+
+sub ensure_org_level_environment_file_exists {
+	my ($parent,$kit,$version,@features) = @_;
+
+	my %existing_info;
+	if (-e $parent) {
+		%existing_info = %{LoadFile($parent)};
+		explain "Using existing #C{$parent} file as base config.";
+	} else {
+		open my $fh, ">", $parent or die "Couldn't write to $parent: $!";
+		print $fh <<EOF;
+---
+kit:
+  name:     $kit
+  version:  $version
+EOF
+		if (@features) {
+			print $fh "  features:\n";
+			print $fh "  - $_\n" foreach (@features);
+		} else {
+			print $fh "  features: []\n";
+		}
+		%existing_info = (
+			kit => {
+				name => $kit,
+				version => $version,
+				features => \@features
+			}
+		);
+		close $fh; $fh = undef;
+		explain "Created new #C{$parent} file for $kit/$version";
+	}
+	return %existing_info;
 }
 
 sub kit_yaml_files {
@@ -4213,6 +4219,8 @@ sub {
 	my $err = check_env_name_for_errors($name);
 	die "Invalid environment name '$name': $err\n" if $err;
 	-f "$name.yml" and die "Environment '$name' already exists\n";
+	my $deployment = $name . "-" . deployment_suffix;
+	my $prefix = ($options{prefix} ? $options{prefix} : (vault_slug($name).'/'.deployment_suffix));
 
 	at_exit(sub {
 		# remove the env file if either prereqs check or vaultification fails
@@ -4222,7 +4230,7 @@ sub {
 	check_prereqs;
 	explain "Generating new environment #C{$name}...\n";
 
-	my ($kit, $version);
+	my ($kit, $version, @features, $kit_dir);
 	if ($options{kit}) {
 		($kit, $version) = extract_kit_name_and_version($options{kit});
 	} else {
@@ -4230,19 +4238,14 @@ sub {
 	}
 
 	if ($kit && $kit ne "dev") {
+		$kit_dir = get_kit($kit,$version);
 		explain "Using compiled kit $kit/$version...\n";
 	} else {
 		explain "Using local development kit (./dev)...";
 		$kit = "dev";
 		$version = "latest";
+		$kit_dir = "./dev";
 	}
-
-	my $meta = read_kit_metadata($kit, $version);
-	check_kit_prereqs($kit, $version);
-
-	my @features = prompt_for_env_features($kit, $version, $meta);
-	my $deployment = $name . "-" . deployment_suffix;
-	my $prefix = ($options{prefix} ? $options{prefix} : (vault_slug($name).'/'.deployment_suffix));
 
 	if ($options{secrets}) {
 		target_vault($options{vault});
@@ -4250,15 +4253,32 @@ sub {
 		$ENV{NOVAULT} = 'y';
 	}
 
-	my $params = process_kit_params(kit          => $kit,
-									version      => $version,
-									env          => $name,
-									vault_prefix => $prefix,
-									params       => $meta->{params} || [],
-									features     => \@features);
-	$params = run_param_hook($kit, $version, $name, $prefix, $params, @features);
+	my $meta = read_kit_metadata($kit, $version);
+	my $new_script=kit_file($kit,$version,"hooks/new",0);
+	if (-f $new_script) {
+		chmod_or_fail(0755, $new_script) unless -x $new_script;
+		my $curdir = Cwd::getcwd;
+		my $out = qx(cd $kit_dir && $new_script $curdir $name);
+		die "Could not create new environment $name using kit $kit/$version"
+			if ($! >> 8);
+		die "New environment '$name' was not generated.  Contact your kit developer for a fix"
+			unless -f "$name.yml";
+		@features = get_key($name, 'kit.features', []);
+		(my $parent = $name) =~ s/-.*/.yml/;
+		ensure_org_level_environment_file_exists($parent,$kit,$version);
+	} else {
+		check_kit_prereqs($kit, $version);
+		@features = prompt_for_env_features($kit, $version, $meta);
+		my $params = process_kit_params(kit          => $kit,
+										version      => $version,
+										env          => $name,
+										vault_prefix => $prefix,
+										params       => $meta->{params} || [],
+										features     => \@features);
+		$params = run_param_hook($kit, $version, $name, $prefix, $params, @features);
 
-	new_environment($meta, $kit, $version, $name, $prefix, $params, @features);
+		new_environment($meta, $kit, $version, $name, $prefix, $params, @features);
+	}
 
 	if ($options{secrets}) {
 		explain "Generating secrets / credentials (in secret/$prefix)...\n";

--- a/bin/genesis
+++ b/bin/genesis
@@ -554,7 +554,7 @@ sub kit_yaml_files {
 	my $dir = 'dev';
 	if ($kit && $version) {
 		$dir = get_kit($kit,$version);
-	} 
+	}
 	return kit_yaml_files_in($kit,$version,$env, $dir, @features);
 }
 
@@ -650,7 +650,7 @@ sub blueprint_script_helper {
 	|	declare -a invalid
 	|	for have in \$GENESIS_REQUESTED_FEATURES; do
 	|		local found='';
-	|		for valid in "\$@"; do 
+	|		for valid in "\$@"; do
 	|			[[ "\$have" == "\$valid" ]] && found=1 && break
 	|		done
 	|		[[ -n \$found ]] || invalid+=(\$wanted)
@@ -685,7 +685,7 @@ sub blueprint_script_helper {
 	|export -f validate_features
 	|
 	|EOF
-	
+
 	return mkfile_or_fail("$helper_dir/blueprint_helper",$out);
 }
 
@@ -4228,6 +4228,7 @@ sub {
 	} else {
 		($kit, $version) = latest_kit_name_and_version();
 	}
+
 	if ($kit && $kit ne "dev") {
 		explain "Using compiled kit $kit/$version...\n";
 	} else {
@@ -4829,10 +4830,10 @@ EOF
 EOF
 	}
 	my $role_op = $pipeline->{vault}{role}
-		? "vault \"$pipeline->{vault}{role}\"" 
+		? "vault \"$pipeline->{vault}{role}\""
 		: "param \"Please provide a vault path for pipeline.vault.role\"";
 	my $secret_op = $pipeline->{vault}{secret}
-		? "vault \"$pipeline->{vault}{secret}\"" 
+		? "vault \"$pipeline->{vault}{secret}\""
 		: "param \"Please provide a vault path for pipeline.vault.secret\"";
 	print $OUT <<"EOF";
     private_key: (( vault "$pipeline->{git}{private_key}" ))

--- a/bin/genesis
+++ b/bin/genesis
@@ -346,7 +346,14 @@ sub validate_features  {
 	for my $sk (@{$meta->{"${label}s"}}) {
 		if ($sk->{choices}) {
 			my $matches = 0;
-			my $min_matches = 1;
+			my ($min_matches,$max_matches) = (1,1);
+			if (defined $sk->{pick}) {
+				if ($sk->{pick} =~ /^(?:(\d+)|(\d+)?-(\d+)?)$/) {
+					($min_matches,$max_matches) = (defined $1) ? ($1,$1) : ($2, $3);
+				} else {
+					$! = 2; die "There is a problem with kit $kit/$version: $sk->{type} pick invalid.  Please contact the kit author for a fix";
+				}
+			}
 			my @choices;
 			for my $choice (@{$sk->{choices}}) {
 				push @choices, $choice->{$label} if defined $choice && defined $choice->{$label};
@@ -357,10 +364,10 @@ sub validate_features  {
 				}
 			}
 			my $choices = join(", ", map { "'$_'" } @choices);
-			if ($matches > 1) {
+			if ($max_matches && $matches > $max_matches) {
 				die "You selected too many ${label}s for your $sk->{type}. Should be only one of $choices\n";
 			}
-			if ($matches < $min_matches) {
+			if ($min_matches && $matches < $min_matches) {
 				die "You must select a $label to provide your $sk->{type}. Should be one of $choices\n";
 			}
 		}

--- a/bin/genesis
+++ b/bin/genesis
@@ -296,12 +296,12 @@ sub in_repo_dir {
 }
 
 # workdir;
-my $WORKDIR;
+my %WORKDIR;
 sub workdir {
-	if (!defined $WORKDIR) {
-		$WORKDIR = tempdir(CLEANUP => 1);
-	}
-	return $WORKDIR;
+	return $WORKDIR{$_[0]} if ($_[0] && defined $WORKDIR{$_[0]});
+	my $dir = tempdir(CLEANUP => 1);
+	$WORKDIR{$_[0]} = $dir if $_[0];
+	return $dir;
 }
 
 # get_file $path
@@ -558,9 +558,7 @@ sub kit_yaml_files {
 
 	my $dir = 'dev';
 	if ($kit && $version) {
-		$dir = workdir();
-		qx(tar -xz -C $dir --strip-components 1 -f .genesis/kits/$kit-$version.tar.gz);
-		$? == 0 or die;
+		$dir = get_kit($kit,$version);
 	} 
 	return kit_yaml_files_in($env, $dir, @features);
 }
@@ -630,6 +628,19 @@ sub unique_suffix {
 		push @pre, $a;
 	}
 	return join('-', @pre), @b;
+}
+
+our %KIT_CACHE_DIR;
+sub get_kit {
+	my ($kit,$version) = @_;
+	unless (exists $KIT_CACHE_DIR{"$kit/$version"}) {
+		my $dir = workdir('kit');
+		die "Kit $kit/$version not found!\n" unless -e ".genesis/kits/$kit-$version.tar.gz";
+		qx(tar -xz -C $dir --strip-components 1 -f .genesis/kits/$kit-$version.tar.gz);
+		$? == 0 or die;
+		$KIT_CACHE_DIR{"$kit/$version"} = $dir;
+	}
+	return $KIT_CACHE_DIR{"$kit/$version"};
 }
 
 sub mergeable_yaml_files {
@@ -3012,11 +3023,16 @@ sub kit_file {
 	-f ".genesis/kits/$kit-$version.tar.gz"
 		or die "Kit $kit/$version not found in .genesis/kits!\n";
 
-	my $tmp = workdir();
-	qx(tar -C $tmp -xzf .genesis/kits/$kit-$version.tar.gz $kit-$version/$relpath 2>/dev/null);
-	!$required || -f "$tmp/$kit-$version/$relpath"
+	my $dir;
+	if (exists $KIT_CACHE_DIR{"$kit/$version"}) {
+		$dir = $KIT_CACHE_DIR{"$kit/$version"};
+	} else {
+		$dir = workdir('kit');
+		qx(tar -C $dir -xz --strip-components 1 -f .genesis/kits/$kit-$version.tar.gz $kit-$version/$relpath 2>/dev/null);
+	}
+	!$required || -f "$dir/$relpath"
 		or die "$relpath not found in $kit-$version kit. Please contact your kit author for a fix.\n";
-	return "$tmp/$kit-$version/$relpath";
+	return "$dir/$relpath";
 }
 
 sub download_kit_tarball

--- a/bin/genesis
+++ b/bin/genesis
@@ -337,9 +337,8 @@ sub validate_features  {
 	my $label = defined($meta->{subkits}) ? "subkit" : "feature";
 	for my $sk (@features) {
 		die "You specified a feature without a name\n" unless $sk;
-		-d kit_file($kit, $version, "features/$sk", 0) ||
-		-d kit_file($kit, $version, "subkits/$sk", 0) ||
-		die "No $label '$sk' found in kit $k/$v.\n";
+		die "No subkit '$sk' found in kit $k/$v.\n"
+			if $label eq "subkit" && ! -d  kit_file($kit, $version, "subkits/$sk", 0);
 	}
 
 	my %requested_features = map { $_ => 1 } @features;
@@ -540,34 +539,154 @@ EOF
 	explain "Created #C{$file} environment file";
 }
 
-sub kit_yaml_files_in {
-	my ($env_file, $dir, @features) = @_;
-	$env_file =~ s/(\.yml)?$/.yml/;
-	my @files;
-	my $features_dir = (-d "$dir/features") ? 'features' : 'subkits';
-	@files = glob "$dir/base/*.yml";
-	push @files, map { glob "$dir/$features_dir/$_/*.yml" } @features;
-	return @files;
-}
-
 sub kit_yaml_files {
 	my ($env) = @_;
 	my @files;
 
-	my $kit     = get_key($env, 'kit.name', "dev");
-	my $version = get_key($env, 'kit.version');
-	die "No kit/version detected in $env.\n"
-		unless $kit && ($kit eq 'dev' || $version);
+	my ($kit,$version) = kit_name_and_version_for($env);
+	$kit ||= "dev";
+	die "No kit/version detected in $env.\n" unless $kit && ($kit eq 'dev' || $version);
 
 	my @features = @{get_key($env, 'kit.features', get_key($env, 'kit.subkits',[]))};
 	my $meta = read_kit_metadata($kit, $version);
-	validate_features($kit, $version, $meta, @features);
+	validate_features($kit, $version, $meta, @features) unless -f kit_file($kit,$version,"hooks/blueprint",0);
 
 	my $dir = 'dev';
 	if ($kit && $version) {
 		$dir = get_kit($kit,$version);
 	} 
-	return kit_yaml_files_in($env, $dir, @features);
+	return kit_yaml_files_in($kit,$version,$env, $dir, @features);
+}
+
+sub kit_yaml_files_in {
+	my ($kit,$version,$env, $dir, @features) = @_;
+	my @files;
+	# use hooks/blueprint script if present
+	my $blueprint_script_path = "$dir/hooks/blueprint";
+	if (-f $blueprint_script_path) {
+		pushd($dir);
+		-x $blueprint_script_path || chmod_or_fail 0755,$blueprint_script_path;
+		my $helper = blueprint_script_helper($kit,$version,$env,@features);
+		my $script = clean_heredoc(<<"			|EOF");
+			|source "$helper"
+			|$blueprint_script_path
+			|EOF
+		my $result = qx($script);
+		if ($? >> 8) {
+			error "#R{ERROR}: Cound not execute $kit/$version hooks/blueprint script successfully:\n";
+			exit 2;
+		}
+		@files = map {Cwd::abs_path $_} grep {$_} split(" ", $result);
+		popd;
+		my @missing_files = grep {! -e $_} @files;
+		if (@missing_files) {
+			error "%s",
+				"#R{ERROR:} Missing $kit/$version files required to satisfy selected features in #C{$env}:\n  - ",
+				join('\n  - ',@missing_files),
+				"\n\nPlease contact kit author to get a fix.\n";
+			exit 2
+		}
+	} else {
+		my $features_dir = (-d "$dir/features") ? 'features' : 'subkits';
+		@files = glob "$dir/base/*.yml";
+		push @files, map { glob "$dir/$features_dir/$_/*.yml" } @features;
+	}
+	return @files;
+}
+
+sub generate_blueprint_script {
+	my (@features) = @_;
+	return clean_heredoc(<<"	|EOF");
+	|#!/bin/bash
+	|# Genesis hooks/blueprint script
+	|#
+	|# This script outputs the list of merge files needed to support the desired
+	|# feature set selected by the environment parameter file.  As generated, it
+	|# lists all *.yml files in the base, then all *.yml files in each detected
+	|# feature directory, in the order the features are specified in the environment
+	|# yml file.  If finer control is desired, add logic around the wants_kit_feature()
+	|# function (takes a feature as a string, returns exit code 0 if present, non-
+	|# zero exit code otherwise).
+	|
+	|set -eu
+	|
+	|validate_features ${\join("\\\n                  ", map {"'$_' "} @features)}
+	|
+	|declare -a manifests
+	|manifests+=(base/*.yml)
+	|
+	|for dir in features/*; do
+	|	sub=\$(basename \$dir)
+	|	if want_feature \$sub; then
+	|		manifests+=(\$dir/*.yml)
+	|	fi
+	|done
+    |echo \${manifests[@]}
+	|EOF
+}
+
+sub blueprint_script_helper {
+	# Assumes it will be executed in the base of the kit directory
+	# by the kit_yaml_files_in command.
+	my ($kit,$version,$env,@features) = @_;
+	my $env_file = get_env_file($env);
+	my $helper_dir = workdir('helper');
+	my $out = clean_heredoc(<<"	|EOF");
+	|export GENESIS_KIT_NAME="$kit";
+	|export GENESIS_KIT_VERSION="$version";
+	|export GENESIS_ENV_FILE="$env_file";
+	|export GENESIS_REQUESTED_FEATURES="${\join(' ', @features)}"
+	|
+	|want_feature() {
+	|	want=\${1:?want_feature() -- must specify a feature}
+	|	for feature in \$GENESIS_REQUESTED_FEATURES; do
+	|		[[ "\$want" == "\$feature" ]] && return 0
+	|	done
+	|	return 1
+	|}
+	|export -f want_feature
+	|
+	|invalid_features() {
+	|	declare -a invalid
+	|	for have in \$GENESIS_REQUESTED_FEATURES; do
+	|		local found='';
+	|		for valid in "\$@"; do 
+	|			[[ "\$have" == "\$valid" ]] && found=1 && break
+	|		done
+	|		[[ -n \$found ]] || invalid+=(\$wanted)
+	|	done
+	|	echo "\${invalid[@]}"
+	|	return 0
+	|}
+	|export -f invalid_features
+	|
+	|valid_features() {
+	|	for have in \$GENESIS_ENV_FEATURES; do
+	|		local found='';
+	|		for valid in "\$@"; do
+	|			[[ "\${have}" = "\${valid}" ]] && found=1 && break
+	|		done
+	|		[[ -n \$found ]] || return 1
+	|	done
+	|	return 0
+	|}
+	|export -f valid_features
+	|
+	|validate_features() {
+	|	if ! valid_features "\$@"; then
+	|		echo >&2 "\$GENESIS_KIT_NAME/\$GENESIS_KIT_VERSION does not understand the following feature flags:"
+	|		for bad in \$(invalid_features "\$@"); do
+	|			echo >&2 " - \$bad"
+	|		done
+	|		[[ -f "feature_usage.txt" ]] && echo >&2 "" && cat "feature_usage.txt"
+	|		exit 1
+	|	fi
+	|}
+	|export -f validate_features
+	|
+	|EOF
+	
+	return mkfile_or_fail("$helper_dir/blueprint_helper",$out);
 }
 
 # takes a list of tokens, in order, and generates
@@ -5046,11 +5165,10 @@ EOF
 
 	# Features (backwards compatibility named Subkits)
 	mkdir_or_fail "$dir/features";
-	my $feature_groups="";
-	my $feature_param_groups="";
-	my $feature_prompts="";
+	my ($feature_groups, $feature_param_groups, $feature_prompts, @feature_names);
 	foreach my $feature_req (@_) {
 		my ($feature,$prompt) = split("=",$feature_req, 2);
+		push @feature_names, $feature;
 		mkdir_or_fail "$dir/features/$feature";
 		$feature_groups .= "  $feature: {}\n";
 		$feature_param_groups .= "  $feature: []\n";
@@ -5153,7 +5271,10 @@ might require, like load balancers.
 
 EOF
 
-explain "\n#G{Created new Genesis kit '}#C{$options{name}}#G{' in directory }#C{$dir}\n\n"
+	mkdir_or_fail "$dir/hooks";
+	mkfile_or_fail "$dir/hooks/blueprint", generate_blueprint_script(@feature_names);
+
+	explain "\n#G{Created new Genesis kit '}#C{$options{name}}#G{' in directory }#C{$dir}\n\n"
 });
 
 # }}}

--- a/bin/genesis
+++ b/bin/genesis
@@ -232,7 +232,8 @@ sub mkfile_or_fail {
 		print $fh $content;
 		close $fh;
 	} or die "Error creating file $file: $!\n";
-	chmod_or_fail $mode, $file if defined $mode;
+	chmod_or_fail($mode, $file) if defined $mode;
+	return $file;
 }
 
 # mkdir_or_fail $dir;
@@ -242,7 +243,8 @@ sub mkdir_or_fail {
 		debug "creating directory $dir/";
 		system("mkdir", "-p", "$dir/") == 0 or die "Unable to create directory $dir/: $!\n";
 	}
-	chmod_or_fail $mode, $dir if defined $mode;
+	chmod_or_fail($mode, $dir) if defined $mode;
+	return $dir;
 }
 # chdir_or_fail $dir;
 sub chdir_or_fail {

--- a/bin/genesis
+++ b/bin/genesis
@@ -677,6 +677,12 @@ sub standalone_environment_yaml_files {
 	grep { has_own_key($_, "params.env") } @envs;
 }
 
+sub get_env_file {
+	my ($env) = @_;
+	$env =~ s/.yml$//;
+	return $env.".yml";
+}
+
 sub has_key {
 	my ($file, $key) = @_;
 	for (mergeable_yaml_files $file) {

--- a/bin/genesis
+++ b/bin/genesis
@@ -5066,20 +5066,31 @@ sub {
 
 command("yamls", <<EOF,
 genesis v$VERSION
-USAGE: genesis yamls deployment-env.yml
+USAGE: genesis yamls [--include-kit] deployment-env.yml
 
 OPTIONS
+      --include-kit This is also include the files that will be merges from the kit.
 $GLOBAL_USAGE
 EOF
 sub {
 	my %options;
 	options(\@_, \%options, qw/
-		rotate
+		include-kit
 	/);
 	usage(1) if @_ != 1;
 	check_prereqs;
 
-	print "$_\n" for mergeable_yaml_files($_[0]);
+	my ($kit,$version) = kit_name_and_version_for($_[0]);
+	my @yamls;
+	if ($options{"include-kit"}) {
+		push @yamls, kit_yaml_files($_[0]);
+		if ($kit && $kit ne "dev") {
+			my $cache_dir = Cwd::abs_path($KIT_CACHE_DIR{"$kit/$version"});
+			@yamls = map {$_ =~ s%^$cache_dir/%\@kit($kit/$version):%; $_} @yamls;
+		}
+	}
+	push @yamls, mergeable_yaml_files($_[0]);
+	print "$_\n" for @yamls;
 });
 
 # }}}

--- a/bin/genesis
+++ b/bin/genesis
@@ -1460,7 +1460,6 @@ EOF
 
 sub merge_files {
 	my ($env, $options) = @_;
-	$env =~ s/(\.yml)?$/.yml/;
 
 	my @files = ();
 	push @files, base_yaml_files($env);

--- a/t/features.t
+++ b/t/features.t
@@ -33,10 +33,9 @@ properties:
     type: webdav
 
 EOF
-
 run_fails "genesis manifest -c cloud.yml use-the-wrong-thing >$tmp/errors 2>&1", undef;
 is get_file("$tmp/errors"), <<EOF, "manifest generate fails with an invalid blobstore feature";
-No feature 'magic' found in kit dev/latest.
+You must select a feature to provide your blobstore. Should be one of 'webdav', 's3'
 EOF
 
 run_fails "genesis manifest -c cloud.yml use-nothing >$tmp/errors 2>&1", undef;

--- a/t/kit-validation.t
+++ b/t/kit-validation.t
@@ -14,7 +14,7 @@ chdir $dir;
 
 reprovision kit => 'invalid-kit';
 
-run_fails "genesis new failures-galore > errors 2>&1", 255, "Invalid kits fail to validate";
+run_fails "genesis new failures-galore --no-secret > errors 2>&1", 255, "Invalid kits fail to validate";
 eq_or_diff get_file("errors"), <<EOF, "Invalid kits generate expected error messages";
 Generating new environment failures-galore...
 

--- a/t/prereqs.t
+++ b/t/prereqs.t
@@ -36,7 +36,7 @@ ok -f "using-dev-genesis.yml", "Deployment environment file should not be create
 
 my $bin = compiled_genesis "9.0.1";
 
-($pass, $rc, $msg) = run_fails "$bin new something-new", 86;
+($pass, $rc, $msg) = run_fails "$bin new something-new --no-secrets", 86;
 matches $msg, qr'.*ERROR:.* Kit version-prereq/1.0.0 requires Genesis version 9.5.2, but installed Genesis is only version 9.0.1.',"Genesis not new enough";
 doesnt_match $msg, qr'New environment something-new provisioned.', "Did not create new environment 'something-new'";
 ok ! -f "something.yml", "Org environment file should not be created, when prereqs fails";
@@ -57,7 +57,7 @@ ok -f "something.yml", "Org environment file should be created, when version mee
 ok -f "something-newer.yml", "Deployment environment file should be created, when version meets minimum";
 
 reprovision kit =>'version-prereq-bad';
-($pass, $rc, $msg) = run_fails "$bin new something-crazy", 255;
+($pass, $rc, $msg) = run_fails "$bin new something-crazy --no-secrets", 255;
 
 matches $msg, qr'.*ERROR:.* The following errors have been encountered validating the dev/latest kit:',"kit has errors";
 matches $msg, qr% - Specified minimum Genesis version of '~>4.5' for kit is invalid.%,"kit has bad min version";


### PR DESCRIPTION
Significant refactor to allow advanced kit authors to do operations that are of of the current scope or ability of Genesis.  This is done by two new hooks:

hooks/new - instead of relying on kit.yml and the optional subkit and params hooks, the new script is completely responsible for asking all questions and writing the env YAML file.

hooks/blueprint - this completes the transition from subkits to features by allowing this script to determine the correct collection and order of files to merge given the list of desired features.
