### PR TITLE
Localize BOSH cred usage to prevent new X509 error

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -4574,9 +4574,9 @@ sub prompt_for_boshes_and_stemcells_for {
 		my ($stemcells, %candidates) = ([]);
 		if ($ask_stemcells) {
 			explain "\nFetching stemcells from BOSH...";
-			chomp($ENV{BOSH_CA_CERT} = qx(safe get "$boshenvs{$env}{ca_cert}"));
-			$ENV{BOSH_CLIENT} = $boshenvs{$env}{username};
-			chomp($ENV{BOSH_CLIENT_SECRET} = qx(safe get "$boshenvs{$env}{password}"));
+			chomp(local $ENV{BOSH_CA_CERT} = qx(safe get "$boshenvs{$env}{ca_cert}"));
+			local $ENV{BOSH_CLIENT} = $boshenvs{$env}{username};
+			chomp(local $ENV{BOSH_CLIENT_SECRET} = qx(safe get "$boshenvs{$env}{password}"));
 			my $sc_info = qx($BOSH -e $boshenvs{$env}{url} stemcells);
 			if ($? > 0) {
 				# Couldn't get stemcells - ask for them manually (just die for now)


### PR DESCRIPTION
A previous fix solved the problem when trying to get stemcells if the
BOSH config didn't match the URL used by `genesis ci`, but in doing so,
polluted the ENV space for further commands.  This make those changes
local to just where its needed when retrieving the stemcells.