### PR TITLE
Ignore garbage prepended to vault version string

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -3068,7 +3068,7 @@ sub check_prereqs {
 	if (!$version) {
 		push @errors, "Missing `vault' - install Vault from #B{https://www.vaultproject.io/downloads.html}";
 	} else {
-		chomp($version); $version =~ s/^vault v(\S+).*/$1/i;
+		chomp($version); $version =~ s/.*vault v(\S+).*/$1/i;
 		if (!new_enough("vault", $version, $VAULT_MIN_VERSION)) {
 			push @errors, "Vault v${version} is installed, but Genesis requires #R{at least $VAULT_MIN_VERSION} - upgrade your Vault, via #B{https://www.vaultproject.io/downloads.html}";
 		}

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,4 +1,4 @@
-# Improvements 
+# Improvements
 
 * Certificates can now be marked as 'fixed' in the kit.yml, so
   that they don't rotate when credentials do.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,6 +1,3 @@
-# Improvements
+# Bug Fixes
 
-- Genesis no longer honors BOSH_ENVIRONMENT, because it determines
-  its BOSH environment from the params.bosh (if present) or
-  params.env (which must be present).  This cuts down on confusion
-  and confoundment.
+* Correctly detects vault versions 0.9.2 and higher


### PR DESCRIPTION
Vault added ANSI control sequence to the start of their version string from 0.9.2 onward, which confuses the version detection code in genesis.  This resolves the problem by ignoring it :)