### PR TITLE
Fixup prompt for ip

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -6334,6 +6334,7 @@ OPTIONS
       --msg "x"         specify the message to print on validation failure, default
                         is specific to the validation type used.
       --invert          (boolean only) invert the answer (true becomes 0, false 1)
+      --echo            (secret-line only) echo what the user types to the screen
 
 GLOBAL OPTIONS (may not apply)
 $GLOBAL_USAGE
@@ -6349,6 +6350,7 @@ sub {
 		max|M=i
 		option|o=s@
 		invert
+		echo
 	));
 	usage(1) if @_ < 2 || @_ > 3; # prompt is optional, type and path are not
 	check_prereqs(no_repo_needed => 1);

--- a/bin/genesis
+++ b/bin/genesis
@@ -1133,6 +1133,14 @@ sub __prompt_for_line {
 	if (defined($validation)) {
 		if (ref($validation) eq 'CODE') {
 			$validate = $validation; # Only used by internal usage of prompts
+		} elsif ($validation eq "ip") {
+			$validate = sub() {
+				my @ipbits = split(/\./, $_[0]);
+				my $msg = ($_[1] ? $_[1] :"$_[0] is not a valid IPv4 address");
+				return "" if scalar(grep {$_ =~ /^\d+$/ && $_ !~ /^0./ && $_ < 256} @ipbits) == 4;
+				return "$msg: octets cannot be zero-padded" if scalar(grep {$_ =~  /^0./} @ipbits);
+				return $msg;
+			}
 		} elsif ($validation eq "url") {
 			$validate = sub() {
 				return "" if (is_valid_uri($_[0]));
@@ -3541,7 +3549,7 @@ sub validate_kit_metadata {
 								$param->{validate} !~ m/^!?\[([^,]+(,[^,]+)*)]$/            && # new invertable comma-separated list
 								$param->{validate} !~ m/^((^|,)[^,]+){2,}$/                 && # comma-separated list
 								$param->{validate} !~ m/^-?\d+(\.\d+)?--?\d+(\.\d+)?$/      && # range
-								$param->{validate} !~ m/^(vault_path(_and_key)?|url|port)$/ ){ # key-words
+								$param->{validate} !~ m/^(vault_path(_and_key)?|url|port|ip)$/ ){ # key-words
 								push @errors, "$parameter has an invalid validation formula";
 							}
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -723,7 +723,7 @@ sub new_script_helper {
 	|		fi
 	|		if [[ \$__type =~ ^multi- ]] ; then
 	|			local __i
-	|			eval "unset \$__var __i"
+	|			eval "unset \$__var"
 	|			eval "while IFS= read -r -d '' \\"\${__var}[__i++]\\"; do :; done < \\"\$__tmpfile\\""
 	|			eval "\$__var=(\\"\\\${\${__var}[@]:1}\\")"
 	|		else
@@ -731,6 +731,7 @@ sub new_script_helper {
 	|		fi
 	|		rm -f "\$__tmpfile"
 	|	fi
+	|	return 0
 	|}
 	|export -f prompt_for
 	|

--- a/t/kits/ask-params/kit.yml
+++ b/t/kits/ask-params/kit.yml
@@ -198,6 +198,11 @@ params:
       ask: 'URL #6'
       validate: url
 
+    - param: ipaddress
+      description: Need a url
+      ask: IP Address
+      validate: ip
+
     - param: validity-vault_path
       description: Need a vault path
       ask: Specify the path

--- a/t/kits/ask-params/kit.yml
+++ b/t/kits/ask-params/kit.yml
@@ -203,6 +203,21 @@ params:
       ask: IP Address
       validate: ip
 
+    - param: loopback-ipaddress
+      description: Need your loopback IP address
+      ask: Loopback IP Address
+      validate: ip
+
+    - param: listen-on-ip
+      description: Listen on what IP address
+      ask: Listening IP Address
+      validate: ip
+
+    - param: mask
+      description: Internal network mask
+      ask: Network Mask
+      validate: ip
+
     - param: validity-vault_path
       description: Need a vault path
       ask: Specify the path

--- a/t/param-asking.t
+++ b/t/param-asking.t
@@ -349,6 +349,53 @@ expect_ok "URL parsing - finish up", $cmd, [
   }
 ];
 
+
+expect_ok "IP parsing - initial prompt", $cmd, [
+  "IP Address[\r\n]{1,2}>", sub {
+    $_[0]->send("mysite.example.com\n");
+  }
+];
+expect_ok "IP parsing - used domain name", $cmd, [
+  "Specify the path", sub {
+    fail "Invalid IP address not correctly identified: used domain name";
+  }], [
+  "mysite.example.com is not a valid IPv4 address[\r\n]{1,2}>", sub {
+    $_[0]->send("123.045.067.008\n");
+  }
+];
+expect_ok "IP parsing - used leading zeros", $cmd, [
+  "Specify the path", sub {
+    fail "Invalid IP address not correctly identified: used leading zeros";
+  }], [
+  "123.045.067.008 is not a valid IPv4 address: octets cannot be zero-padded[\r\n]{1,2}>", sub {
+    $_[0]->send("123.456.789.10\n");
+  }
+];
+expect_ok "IP parsing - octets too big", $cmd, [
+  "Specify the path", sub {
+    fail "Invalid IP address not correctly identified: octets too big";
+  }], [
+  "123.456.789.10 is not a valid IPv4 address[\r\n]{1,2}>", sub {
+    $_[0]->send("123.45.67\n");
+  }
+];
+expect_ok "IP parsing - not enough octets", $cmd, [
+  "Specify the path", sub {
+    fail "Invalid IP address not correctly identified: not enough octets";
+  }], [
+  "123.45.67 is not a valid IPv4 address[\r\n]{1,2}>", sub {
+    $_[0]->send("123.4.5.6.78\n");
+  }
+];
+expect_ok "IP parsing - too many octets", $cmd, [
+  "Specify the path", sub {
+    fail "Invalid IP address not correctly identified: too many octets";
+  }], [
+  "123.4.5.6.78 is not a valid IPv4 address[\r\n]{1,2}>", sub {
+    $_[0]->send("123.4.5.67\n");
+  }
+];
+
 expect_ok "Vault paths with --no-secrets option", $cmd, [
   "Warning:.* Cannot validate vault paths when --no-secrets option specified[\r\n]{1,2}Specify the path[\r\n]{1,2}>", sub {
     $_[0]->send("/secret/this/path/does/not/exist\n");
@@ -524,6 +571,9 @@ params:
 
   # Give me a bad URL (not that kind)
   test-bad-URL-handling: https://github.com/starkandwayne/genesis/blob/master/t/param-asking.t#L345
+
+  # Need a url
+  ipaddress: 123.4.5.67
 
   # Need a vault path
   validity-vault_path: /secret/this/path/does/not/exist

--- a/t/param-asking.t
+++ b/t/param-asking.t
@@ -395,6 +395,21 @@ expect_ok "IP parsing - too many octets", $cmd, [
     $_[0]->send("123.4.5.67\n");
   }
 ];
+expect_ok "IP parsing - loopback", $cmd, [
+  "Loopback IP Address[\r\n]{1,2}>", sub {
+    $_[0]->send("127.0.0.1\n");
+  }
+];
+expect_ok "IP parsing - unspecified ip address ", $cmd, [
+  "Listening IP Address[\r\n]{1,2}>", sub {
+    $_[0]->send("0.0.0.0\n");
+  }
+];
+expect_ok "IP parsing - bounds checking ", $cmd, [
+  "Network Mask[\r\n]{1,2}>", sub {
+    $_[0]->send("10.0.255.255\n");
+  }
+];
 
 expect_ok "Vault paths with --no-secrets option", $cmd, [
   "Warning:.* Cannot validate vault paths when --no-secrets option specified[\r\n]{1,2}Specify the path[\r\n]{1,2}>", sub {
@@ -574,6 +589,15 @@ params:
 
   # Need a url
   ipaddress: 123.4.5.67
+
+  # Need your loopback IP address
+  loopback-ipaddress: 127.0.0.1
+
+  # Listen on what IP address
+  listen-on-ip: 0.0.0.0
+
+  # Internal network mask
+  mask: 10.0.255.255
 
   # Need a vault path
   validity-vault_path: /secret/this/path/does/not/exist


### PR DESCRIPTION
Adds ip validation to prompt-for line.

Also fixes issues with hooks/new script that use `set -eu` and adds the missing --echo option for the secret-line prompt.