### PR TITLE
Intelligent Manifest redaction

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1724,8 +1724,11 @@ sub deploy_manifest {
 		$deployment = ".genesis/manifests/$env-state.yml";
 	}
 	my @deploy_opts;
-	foreach (qw/no-redact fix recreate/) {
+	foreach (qw/fix recreate/) {
 		push @deploy_opts, "--$_" if $options->{$_};
+	}
+	if (!$options->{redact}) {
+		push @deploy_opts, "--no-redact";
 	}
 	my $rc = bosh_deploy $target, $deployment, "$dir/manifest.yml", @deploy_opts;
 	return $rc;
@@ -1890,7 +1893,7 @@ sub read_pipeline {
 	}
 	for (keys %{$p->{pipeline}}) {
 		push @errors, "Unrecognized `pipeline.$_' key found."
-			unless m/^(name|public|tagged|errands|vault|git|slack|hipchat|email|boshes|task|layout|layouts|debug|stemcells|skip_upkeep|locker)$/;
+			unless m/^(name|public|tagged|errands|vault|git|slack|hipchat|email|boshes|task|layout|layouts|debug|stemcells|skip_upkeep|locker|unredacted)$/;
 	}
 	for (qw(name vault git boshes)) {
 		push @errors, "`pipeline.$_' is required."
@@ -2150,8 +2153,9 @@ sub parse_pipeline {
 	                         # can have triggered each given environment
 
 	# handle yes/no/y/n/true/false/1/0 in our source YAML.
-	$P->{pipeline}{tagged} = yaml_bool($P->{pipeline}{tagged}, 0);
-	$P->{pipeline}{public} = yaml_bool($P->{pipeline}{public}, 0);
+	$P->{pipeline}{tagged}     = yaml_bool($P->{pipeline}{tagged}, 0);
+	$P->{pipeline}{public}     = yaml_bool($P->{pipeline}{public}, 0);
+	$P->{pipeline}{unredacted} = yaml_bool($P->{pipeline}{unredacted}, 0);
 
 	# some default values, if the user didn't supply any
 	$P->{pipeline}{vault}{role}   ||= "";
@@ -2994,6 +2998,7 @@ EOF
               repository: $pipeline->{pipeline}{task}{image}
               tag:        $pipeline->{pipeline}{task}{version}
           params:
+            CI_NO_REDACT:         $pipeline->{pipeline}{unredacted}
             CURRENT_ENV:          $env
             PREVIOUS_ENV:         $passed
             CACHE_DIR:            $alias-cache
@@ -3067,6 +3072,7 @@ EOF
               repository: $pipeline->{pipeline}{task}{image}
               tag:        $pipeline->{pipeline}{task}{version}
           params:
+            CI_NO_REDACT:       $pipeline->{pipeline}{unredacted}
             CURRENT_ENV:        $env
             ERRAND_NAME:        $errand_name
 
@@ -3112,6 +3118,7 @@ EOF
             path: $genesis_bindir/.genesis/bin/genesis
             args: [ci-generate-cache]
           params:
+            CI_NO_REDACT:    $pipeline->{pipeline}{unredacted}
             CURRENT_ENV:     $env
             WORKING_DIR:     out/git
             OUT_DIR:         cache-out/git
@@ -5193,16 +5200,18 @@ EOF
 
 command("deploy", <<EOF,
 genesis v$VERSION
-USAGE: genesis deploy [-n|--non-interactive] [--fix|--recreate] [--no-redact] env-name[.yml]
+USAGE: genesis deploy [-n|--non-interactive] [--fix|--recreate] [--redact] env-name[.yml]
 
 OPTIONS
 $GLOBAL_USAGE
 EOF
 sub {
-	my %options;
+	my %options = (
+		redact => (!(-t STDIN))
+	);
 	options(\@_, \%options, qw/
 		non-interactive|n
-		no-redact
+		redact
 		fix
 		recreate
 	/);
@@ -6096,7 +6105,8 @@ sub {
 	           role_id     => $ENV{VAULT_ROLE_ID},
 	           secret_id   => $ENV{VAULT_SECRET_ID});
 
-	my $rc = deploy_manifest($ENV{CURRENT_ENV}); # exits if it fails
+	# exits if it fails
+	my $rc = deploy_manifest($ENV{CURRENT_ENV}, { redact => !envset('CI_NO_REDACT') });
 	if ($ENV{PREVIOUS_ENV}) {
 		## rm cache dir
 		## copy previous env cache dir

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,11 @@
+# Improvements
+
+- `genesis deploy` now only redacts in CI/CD pipelines and when
+  run non-interactively (i.e. when not attached to a controlling
+  terminal).
+
+- Genesis pipelines can now be configured in `unredacted: yes`
+  mode, causing them to run `genesis deploy` without redaction.
+  This has the potential to leak sensitive credentials like
+  passwords and keys, so use this with caution, and only on
+  secure Concourse installations that are not publicly viewable.

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -290,6 +290,13 @@ pipeline:
   distributed Concourse implementations.  This is off by default,
   and if you don't know why you would need it, you don't need it.
 
+- **pipeline.unredacted** - Whether or not deployment output will
+  be redacted when run in the pipeline.  This is off by default.
+  If you set it to 'yes', the `genesis deploy` output in pipeline
+  build logs will be unredacted, showing you all of the changes
+  that are taking place, including any changes in potentially
+  sensitive credentials.
+
 - **pipeline.smoke-tests** - The name of the BOSH smoke test
   errand to run after a successsful deployment / upgrade.  If not
   specified, no smoke testing will be carried out.

--- a/t/pipeline.t
+++ b/t/pipeline.t
@@ -57,6 +57,7 @@ jobs:
           BOSH_ENVIRONMENT: https://preprod.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-preprod-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-preprod
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -94,6 +95,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-preprod
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -191,6 +193,7 @@ jobs:
           BOSH_ENVIRONMENT: https://prod.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-prod-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-prod
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -228,6 +231,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-prod
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -295,6 +299,7 @@ jobs:
           BOSH_ENVIRONMENT: https://sandbox.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-sandbox-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-sandbox
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -332,6 +337,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-sandbox
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -613,6 +619,7 @@ jobs:
           BOSH_ENVIRONMENT: https://preprod.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-preprod-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-preprod
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -652,6 +659,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-preprod
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -755,6 +763,7 @@ jobs:
           BOSH_ENVIRONMENT: https://prod.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-prod-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-prod
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -794,6 +803,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-prod
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -867,6 +877,7 @@ jobs:
           BOSH_ENVIRONMENT: https://sandbox.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-sandbox-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-sandbox
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -906,6 +917,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-sandbox
           GIT_BRANCH: master
           GIT_PRIVATE_KEY: |
@@ -1197,6 +1209,7 @@ jobs:
           BOSH_ENVIRONMENT: https://preprod.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: preprod-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-preprod
           DEBUG: 1
           GIT_BRANCH: master
@@ -1240,6 +1253,7 @@ jobs:
           BOSH_CLIENT: pp-admin
           BOSH_CLIENT_SECRET: Ahti2eeth3aewohnee1Phaec
           BOSH_ENVIRONMENT: https://preprod.example.com:25555
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-preprod
           DEBUG: 1
           ERRAND_NAME: a-testing-errand-for-the-ages
@@ -1262,6 +1276,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-preprod
           DEBUG: 1
           GIT_BRANCH: master
@@ -1360,6 +1375,7 @@ jobs:
           BOSH_ENVIRONMENT: https://prod.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: prod-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-prod
           DEBUG: 1
           GIT_BRANCH: master
@@ -1403,6 +1419,7 @@ jobs:
           BOSH_CLIENT: pr-admin
           BOSH_CLIENT_SECRET: eeheelod3veepaepiepee8ahc3rukaefo6equiezuapohS2u
           BOSH_ENVIRONMENT: https://prod.example.com:25555
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-prod
           DEBUG: 1
           ERRAND_NAME: a-testing-errand-for-the-ages
@@ -1425,6 +1442,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-prod
           DEBUG: 1
           GIT_BRANCH: master
@@ -1493,6 +1511,7 @@ jobs:
           BOSH_ENVIRONMENT: https://sandbox.example.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: sandbox-cache
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-sandbox
           DEBUG: 1
           GIT_BRANCH: master
@@ -1536,6 +1555,7 @@ jobs:
           BOSH_CLIENT: sb-admin
           BOSH_CLIENT_SECRET: PaeM2Eip
           BOSH_ENVIRONMENT: https://sandbox.example.com:25555
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-sandbox
           DEBUG: 1
           ERRAND_NAME: a-testing-errand-for-the-ages
@@ -1558,6 +1578,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 0
           CURRENT_ENV: client-aws-1-sandbox
           DEBUG: 1
           GIT_BRANCH: master
@@ -1902,6 +1923,7 @@ jobs:
           BOSH_ENVIRONMENT: https://preprod.bosh-lite.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-preprod-cache
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-preprod
           DEBUG: 1
           GIT_BRANCH: master
@@ -1947,6 +1969,7 @@ jobs:
           BOSH_CLIENT: pp-admin
           BOSH_CLIENT_SECRET: Ahti2eeth3aewohnee1Phaec
           BOSH_ENVIRONMENT: https://preprod.bosh-lite.com:25555
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-preprod
           DEBUG: 1
           ERRAND_NAME: run-something-good
@@ -1971,6 +1994,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-preprod
           DEBUG: 1
           GIT_BRANCH: master
@@ -2177,6 +2201,7 @@ jobs:
           BOSH_ENVIRONMENT: https://prod.bosh-lite.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-prod-cache
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-prod
           DEBUG: 1
           GIT_BRANCH: master
@@ -2222,6 +2247,7 @@ jobs:
           BOSH_CLIENT: pr-admin
           BOSH_CLIENT_SECRET: eeheelod3veepaepiepee8ahc3rukaefo6equiezuapohS2u
           BOSH_ENVIRONMENT: https://prod.bosh-lite.com:25555
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-prod
           DEBUG: 1
           ERRAND_NAME: run-something-good
@@ -2246,6 +2272,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-prod
           DEBUG: 1
           GIT_BRANCH: master
@@ -2413,6 +2440,7 @@ jobs:
           BOSH_ENVIRONMENT: https://sandbox.bosh-lite.com:25555
           BOSH_NON_INTERACTIVE: true
           CACHE_DIR: client-aws-1-sandbox-cache
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-sandbox
           DEBUG: 1
           GIT_BRANCH: master
@@ -2458,6 +2486,7 @@ jobs:
           BOSH_CLIENT: sb-admin
           BOSH_CLIENT_SECRET: PaeM2Eip
           BOSH_ENVIRONMENT: https://sandbox.bosh-lite.com:25555
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-sandbox
           DEBUG: 1
           ERRAND_NAME: run-something-good
@@ -2482,6 +2511,7 @@ jobs:
         outputs:
         - name: cache-out
         params:
+          CI_NO_REDACT: 1
           CURRENT_ENV: client-aws-1-sandbox
           DEBUG: 1
           GIT_BRANCH: master

--- a/t/repos/pipeline-test/ci/aws/pipeline.everything
+++ b/t/repos/pipeline-test/ci/aws/pipeline.everything
@@ -5,6 +5,7 @@ pipeline:
   tagged: on
   errands: [run-something-good]
   debug: true
+  unredacted: yes
 
   task:
     image:   custom/concourse-image


### PR DESCRIPTION
The `genesis deploy` action now runs unredacted when interactive (with a
controlling terminal), and always redacted in CI/CD.