### PR TITLE
Pre genesis metadata fixes

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -156,7 +156,7 @@ sub explain(@) {
 }
 
 sub debug(@) {
-	return unless envset "DEBUG";
+	return unless envset "GENESIS_DEBUG";
 	print STDERR "DEBUG> ";
 	my $colorize = $ENV{NOCOLOR};
 	$ENV{NOCOLOR} = "true" if (! -t STDERR);
@@ -205,10 +205,10 @@ sub controlling_terminal {
 #
 # The latter is recommended as it properly encapsulates/tokenizes the 
 # arguments to prevent accidental expansion or splitting due to quoting
-# and spaces.
+# and spaces.  If using it, remember to quote all variable references.
 #
 # Use this where you would normally use backticks or qx() calls.  It also
-# supports debug output when DEBUG env is set.
+# supports debug output when GENESIS_DEBUG env is set.
 #
 # If called in a scalar context, it will return true if success, false
 # otherwise.  In a list context, it will return the output and the exit code
@@ -1665,7 +1665,7 @@ sub write_stemcell_data {
 	my $stemcells = "{}";
 	if ($ENV{GENESIS_INDEX} ne "no") {
 		my $flags = "-ks";
-		$flags += " -v" if envset 'DEBUG';
+		$flags += " -v" if envset 'GENESIS_DEBUG';
 		$stemcells = `curl $flags $ENV{GENESIS_INDEX}/v1/stemcell/latest | jq '. | map({"key": .name, "value": { "sha1": .sha1, "url": .url}}) | from_entries' -Mc`;
 		die "Unable to contact the genesis index to retrieve stemcell data. Cannot continue." unless ($? == 0);
 	}
@@ -1832,7 +1832,7 @@ sub curl {
 	if ($creds) {
 		$flags .= " -u '$creds'";
 	}
-	if (envset('DEBUG')) {
+	if (envset('GENESIS_DEBUG')) {
 		$flags .= " -v";
 	}
 	my $status = "";
@@ -4214,11 +4214,11 @@ sub options {
 
 	usage(0) if $options->{help};
 
-	$ENV{QUIET}   = 'y' if  $options->{quiet};
-	$ENV{DEBUG}   = 'y' if  $options->{debug};
-	$ENV{TRACE}   = 'y' if  $options->{trace};
-	$ENV{NOCOLOR} = 'y' if !$options->{color};
-	$ENV{OFFLINE} = 'y' if  $options->{offline};
+	$ENV{QUIET}         = 'y' if  $options->{quiet};
+	$ENV{GENESIS_DEBUG} = 'y' if  $options->{debug} || envset "DEBUG";
+	$ENV{TRACE}         = 'y' if  $options->{trace};
+	$ENV{NOCOLOR}       = 'y' if !$options->{color};
+	$ENV{OFFLINE}       = 'y' if  $options->{offline};
 
 	debug("bosh env: ".($options->{environment} || "-same-as-env-file-"));
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -1773,12 +1773,8 @@ sub deploy_manifest {
 		$deployment = ".genesis/manifests/$env-state.yml";
 	}
 	my @deploy_opts;
-	foreach (qw/fix recreate/) {
-		push @deploy_opts, "--$_" if $options->{$_};
-	}
-	if (!$options->{redact}) {
-		push @deploy_opts, "--no-redact";
-	}
+	push @deploy_opts, "--$_" foreach (grep {$options->{$_}} qw/fix recreate dry-run/);
+	push @deploy_opts, "--no-redact" if (!$options->{redact});
 	my $rc = bosh_deploy $target, $deployment, "$dir/manifest.yml", @deploy_opts;
 	return $rc;
 }
@@ -5307,6 +5303,7 @@ sub {
 		redact!
 		fix
 		recreate
+		dry-run
 	/);
 	usage(1) if @_ != 1;
 	check_prereqs;

--- a/bin/genesis
+++ b/bin/genesis
@@ -5757,7 +5757,7 @@ sub {
 	mkdir_or_fail "$temp/$stem";
 	qx(cp -aH $dir/* $temp/$stem);
 
-	qx(rm -rf $temp/$stem/.git $temp/$stem/.gitignore $temp/$stem/*.tar.gz);
+	qx(rm -rf $temp/$stem/.git $temp/$stem/.gitignore $temp/$stem/*.tar.gz $temp/$stem/ci);
 	qx(echo "version: $options{version}" | spruce merge $dir/kit.yml - > $temp/$stem/kit.yml);
 
 	if (!$options{force}) {

--- a/bin/genesis
+++ b/bin/genesis
@@ -200,8 +200,16 @@ sub controlling_terminal {
 }
 
 # Execute the requested command.  You can operate this in two modes:
-#   1) Pass the command as a string will all the arguments in it.
+#
+#   1) Pass the command as a string with all the arguments in it.
+#      eg: execute("safe read auth/approle/role/$role_name/role-id | spruce json | jq -r .role_id | safe paste $role_p $role_k");
+#
 #   2) Pass the command as a template, and the template args as an array
+#      eg: execute('safe read "$1" | spruce json | jq -r .role_id | safe paste "$2" "$3"',
+#                  "auth/approle/role/$role_name/role-id",
+#                  $role_p,
+#                  $role_k
+#          );
 #
 # The latter is recommended as it properly encapsulates/tokenizes the 
 # arguments to prevent accidental expansion or splitting due to quoting
@@ -211,13 +219,21 @@ sub controlling_terminal {
 # supports debug output when GENESIS_DEBUG env is set.
 #
 # If called in a scalar context, it will return true if success, false
-# otherwise.  In a list context, it will return the output and the exit code
+# otherwise.  In a list context, it will return the output and the exit code.
+#
+# Scalar context (often used in conditionals):
+#   if (execute('grep "$1" "$@"', $pattern, @files)) { ... }
+#
+# List context (when you want to capture the output) {
+#   my ($out,$rc) = execute('spruce json "$1" | jq -r "$2"', $_, $filter);
+#   die "Could not find desired key: $out\n" if $rc; # 0 means success
+#   my $key_value = $out;
 sub execute {
 	my ($prog,@args) = @_;
-	my $shell = $ENV{SHELL} || '/bin/bash';
+	my $shell = '/bin/bash';
 	debug "#M{Executing:} `#C{$prog 2>&1}`";
 	if (@args) {
-		unshift @args, $ENV{SHELL};
+		unshift @args, $shell;
 		debug "#m{ - with arguments:}";
 		debug "#m{%4s:} '#c{%s}'", $_, $args[$_] for (1..$#args);
 	}
@@ -237,16 +253,16 @@ sub execute {
 }
 
 sub system_execute {
-	my ($prog) = @_;
-	debug "executing `#C{$prog}`";
-	my $out = system "$prog";
-	my $rc = $?;
-
-	if ($rc != 0) {
-		debug "command exited #R{%d}.", $rc >> 8;
-		return 0;
-	}
-	return 1;
+	my (@args) = @_;
+	debug "executing `#C{$args[0]}`";
+    if (scalar(@args) > 1) {
+        debug "#m{ - with arguments:}";
+        debug "#m{%4s:} '#c{%s}'", $_, $args[$_] for (1..$#args);
+    }
+	my $out = system @args;
+	my $rc = $? >> 8;
+	debug("command exited #R{%d}.", $rc) if $rc;
+	return !$rc;
 }
 
 sub mkfile_or_fail {
@@ -979,8 +995,8 @@ sub find_key {
 	my $filter = build_jq_filter($key);
 	for (@files) {
 		next unless -f $_;
-		my $out = qx(spruce json $_ | jq -r '$filter');
-		return $_ if $? == 0 and $out !~ /^(null\n)?$/;
+		my ($out,$rc) = execute('spruce json "$1" | jq -r "$2"', $_, $filter);
+		return $_ if $rc == 0 and $out !~ /^(null\n)?$/;
 	}
 	return '';
 }
@@ -998,7 +1014,7 @@ sub get_key {
 	my $filter = build_jq_filter($key);
 
 	my ($out,$rc) = execute(
-		'f=$1; shift; spruce merge --skip-eval $@ | spruce json | jq -Mc $f',
+		'f="$1"; shift; spruce merge --skip-eval "$@" | spruce json | jq -Mc "$f"',
 		$filter, mergeable_yaml_files($file)
 	);
 	die "Unable to merge environment files: \n$out\n" if $rc;
@@ -1612,12 +1628,18 @@ sub detect_bosh_version {
 }
 
 sub system_bosh {
-  local $ENV{HTTPS_PROXY} = ''; # bosh dislikes this env var
-  local $ENV{BOSH_ENVIRONMENT} = ''; # ensure using ~/.bosh/config via alias
-  local $ENV{BOSH_CA_CERT} = '';
-  local $ENV{BOSH_CLIENT} = '';
-  local $ENV{BOSH_CLIENT_SECRET} = '';
-  return system_execute(join(" ", $BOSH, @_));
+	my @args = @_;
+	local $ENV{HTTPS_PROXY} = ''; # bosh dislikes this env var
+	local $ENV{BOSH_ENVIRONMENT} = ''; # ensure using ~/.bosh/config via alias
+	local $ENV{BOSH_CA_CERT} = '';
+	local $ENV{BOSH_CLIENT} = '';
+	local $ENV{BOSH_CLIENT_SECRET} = '';
+	if (scalar(@args) > 1) {
+		unshift @args, $BOSH;
+	} else {
+		$args[0] = "$BOSH ".$args[0];
+	}
+	return system_execute($BOSH, @_);
 }
 
 sub qx_bosh {
@@ -1826,8 +1848,10 @@ sub deploy_manifest {
 		$deployment = ".genesis/manifests/$env-state.yml";
 	}
 	my @deploy_opts;
-	push @deploy_opts, "--$_" foreach (grep {$options->{$_}} qw/fix recreate dry-run/);
-	push @deploy_opts, "--no-redact" if (!$options->{redact});
+	push @deploy_opts, "--$_"                for grep {$options->{$_}} qw/fix recreate dry-run/;
+	push @deploy_opts, "--no-redact"         if  !$options->{redact};
+	push @deploy_opts, "--skip-drain=$_"     for @{$options->{'skip-drain'} || []};
+	push @deploy_opts, "--$_=$options->{$_}" for grep {defined $options->{$_}} qw/canaries max-in-flight/;
 	my $rc = bosh_deploy $target, $deployment, "$dir/manifest.yml", @deploy_opts;
 	return $rc;
 }
@@ -5342,10 +5366,35 @@ EOF
 
 command("deploy", <<EOF,
 genesis v$VERSION
-USAGE: genesis deploy [-n|--non-interactive] [--fix|--recreate] [--redact] env-name[.yml]
+USAGE: genesis deploy <options> env-name[.yml]
 
 OPTIONS
 $GLOBAL_USAGE
+  -n, --non-interactive  Do not ask any questions, assume 'y' for any that would
+                         normally be asked.  Allows automation to deploy without
+                         requiring human intervention or expect-style scripting.
+
+      --[no-]redact      Determines if values are shown on the diff output.  By
+                         default, the manifest will be redacted unless being
+                         output to the live console.
+      --skip-drain xxx   Skip running drain scripts for specific instance group.
+                         Can be specified multiple times.
+
+      --canaries #       Override the default number of canary VMs per instance
+                         group.
+
+      --max-in-flight #  Override the default number of maximum VMs in flight
+                         per instance group.
+
+Can specify one of the follow three:
+      --dry-run          Build the manifest and validate it against the current
+                         state of the BOSH director for this deployment, but
+                         doesn't change anything.
+
+      --recreate         Recreate all VMs instead of just applying changes to them.
+
+      --fix              Only recreate VMs that are unresponsive.
+
 EOF
 sub {
 	my %options = (redact => ! controlling_terminal);
@@ -5355,13 +5404,16 @@ sub {
 		fix
 		recreate
 		dry-run
+		skip-drain=s@
+		canaries=i
+		max-in-flight=i
 	/);
 	usage(1) if @_ != 1;
-	my $env = get_env(shift);;
+	my $env = get_env(shift);
 	check_prereqs;
 
-	if ($options{fix} && $options{recreate}) {
-		usage(1,"Cannot specify --fix and --recreate together");
+	if (scalar(grep {$_} ($options{fix}, $options{recreate}, $options{'dry-run'})) > 1) {
+		usage(1,"Can only specify one of --dry-run, --fix or --recreate");
 	}
 
 	if ($options{'non-interactive'}) {
@@ -5830,7 +5882,7 @@ sub {
 		redact!
 	/);
 	usage(1) if @_ != 1;
-	my $env = get_env(shift);;
+	my $env = get_env(shift);
 	check_prereqs;
 
 	$ENV{REDACT} = $options{'redact'} ? "1" : "";

--- a/bin/genesis
+++ b/bin/genesis
@@ -195,6 +195,10 @@ sub vaulted {
 	return !!$ENV{GENESIS_TARGET_VAULT};
 }
 
+sub controlling_terminal {
+	return -t STDOUT;
+}
+
 sub execute {
 	my ($prog) = @_;
 	debug "executing `#C{$prog} 2>&1`";
@@ -5297,12 +5301,10 @@ OPTIONS
 $GLOBAL_USAGE
 EOF
 sub {
-	my %options = (
-		redact => (!(-t STDIN))
-	);
+	my %options = (redact => ! controlling_terminal);
 	options(\@_, \%options, qw/
 		non-interactive|n
-		redact
+		redact!
 		fix
 		recreate
 	/);
@@ -5768,21 +5770,21 @@ $GLOBAL_USAGE
 
   -c, --cloud-config PATH    Path to your downloaded BOSH cloud-config
 
-      --no-redact            Do not redact credentials in the manifest.
-                             USE THIS OPTION WITH GREAT CARE AND CAUTION.
+      --[no-]redact          Determines if vault values are fetched or redacted.
+                             By default, the manifest will be redacted unless
+                             being output to the live console.
 EOF
 sub {
-	my %options;
+	my %options = (redact => ! controlling_terminal);
 	options(\@_, \%options, qw/
 		cloud-config|c=s
-		no-redact
+		redact!
 	/);
 	usage(1) if @_ != 1;
 	my ($env) = @_;
 	check_prereqs;
 
-	$ENV{REDACT} = 'true';
-	$ENV{REDACT} = '' if $options{'no-redact'};
+	$ENV{REDACT} = $options{'redact'} ? "1" : "";
 
 	my $create_env = is_create_env($env);
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -199,20 +199,41 @@ sub controlling_terminal {
 	return -t STDOUT;
 }
 
+# Execute the requested command.  You can operate this in two modes:
+#   1) Pass the command as a string will all the arguments in it.
+#   2) Pass the command as a template, and the template args as an array
+#
+# The latter is recommended as it properly encapsulates/tokenizes the 
+# arguments to prevent accidental expansion or splitting due to quoting
+# and spaces.
+#
+# Use this where you would normally use backticks or qx() calls.  It also
+# supports debug output when DEBUG env is set.
+#
+# If called in a scalar context, it will return true if success, false
+# otherwise.  In a list context, it will return the output and the exit code
 sub execute {
-	my ($prog) = @_;
-	debug "executing `#C{$prog} 2>&1`";
-	my $out = qx($prog 2>&1);
-	my $rc = $?;
+	my ($prog,@args) = @_;
+	my $shell = $ENV{SHELL} || '/bin/bash';
+	debug "#M{Executing:} `#C{$prog 2>&1}`";
+	if (@args) {
+		unshift @args, $ENV{SHELL};
+		debug "#m{ - with arguments:}";
+		debug "#m{%4s:} '#c{%s}'", $_, $args[$_] for (1..$#args);
+	}
+	open my $pipe, "-|", $shell, '-c', $prog, @args;
+	my $out = do { local $/; <$pipe> };
+	my $rc = $? >> 8;
 
 	if ($rc != 0) {
-		debug "command exited #R{%d}.", $rc >> 8;
-		debug "--------------------------------";
+		debug "command exited #R{%d}.  Output:", $rc;
+		debug "#R{vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv}";
 		debug $out;
-		debug "--------------------------------";
-		return 0;
+		debug "#R{^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^}";
+	} else {
+		debug "#g{Command executed successfully.}";
 	}
-	return 1;
+	return wantarray ? ($out, $rc) : ($rc ? 0 : 1);
 }
 
 sub system_execute {

--- a/bin/genesis
+++ b/bin/genesis
@@ -929,8 +929,7 @@ sub mergeable_yaml_files {
 }
 
 sub standalone_environment_yaml_files {
-	my @envs = @_;
-	grep { has_own_key($_, "params.env") } @envs;
+	return grep { find_key("params.env", $_) } @_;
 }
 
 sub get_env_file {
@@ -939,43 +938,61 @@ sub get_env_file {
 	return $env.".yml";
 }
 
-sub has_key {
-	my ($file, $key) = @_;
-	for (mergeable_yaml_files $file) {
-		chomp(my $out = qx(spruce json $_ | jq -r '.$key'));
-		return 1 if $? == 0 and $out ne "null";
+sub build_jq_filter {
+	my ($path) = @_;
+	$path =~ s/^([^\.])/.$1/; # ensure it starts with a .
+	my @path_bits = grep /\S/, split(/([\.\[]+)/, $path);
+	my ($join,$value,$filter);
+	while (@path_bits) {
+		($join,$value,@path_bits) = @path_bits;
+		if ($join eq '.') {
+			$filter .= "$join$value";
+		} elsif ($join =~ /^\.?\[$/ && $value =~ /([-[:word:]]+)=([-[:word:]]+)\]$/) {
+			$filter .= "[] | select(.$1 == \"$2\") | ";
+		} elsif ($join =~ /^\.?\[$/ && $value =~ /(\d+)\]$/) {
+			$filter .= "[$1]";
+		} else {
+			die "Invalid pick path: $join$value\n";
+		}
 	}
-	return 0;
+	$filter =~ s/ \| $//; # clean off trailing pipes if select was last item.
+	return $filter;
 }
 
-sub has_own_key {
-	my ($file, $key) = @_;
-	return 0 unless -f $file;
-	chomp(my $out = qx(spruce json $file | jq -r '.$key'));
-	return 1 if $? == 0 and $out ne "null";
+sub find_key {
+	my ($key, @files) = @_;
+	my $filter = build_jq_filter($key);
+	for (@files) {
+		next unless -f $_;
+		my $out = qx(spruce json $_ | jq -r '$filter');
+		return $_ if $? == 0 and $out !~ /^(null\n)?$/;
+	}
+	return '';
 }
 
+sub has_key {
+	find_key($_[1], reverse mergeable_yaml_files($_[0]));
+}
+
+# Get key from environment file hierarchy.  Returns the default
+# if the key does not exist or is null, otherwise it returns the value of
+# the key (even if value is 0 or empty string.)
 sub get_key {
 	my ($file, $key, $default) = @_;
 	return $default unless has_key($file, $key);
+	my $filter = build_jq_filter($key);
 
-	my $result = Load(spruce_merge({ 'cherry-pick' => $key },
-	                               mergeable_yaml_files($file)));
-	for (grep {$_ !~ m/^\.?$/} split(/(\.|\[[0-9+]\])/, $key)) {
-		if ($_ =~ m/^\[[0-9]+\]$/) {
-			return $default unless @{$result}[0];
-			$result = @{$result}[0];
-		} else {
-			return $default unless exists $result->{$_};
-			$result = $result->{$_};
-		}
-	}
-	return defined $result ? $result : $default;
+	my ($out,$rc) = execute(
+		'f=$1; shift; spruce merge --skip-eval $@ | spruce json | jq -Mc $f',
+		$filter, mergeable_yaml_files($file)
+	);
+	die "Unable to merge environment files: \n$out\n" if $rc;
+	JSON::PP->new->allow_nonref->decode($out);
 }
 
 sub has_feature {
 	my ($file, $feature) = @_;
-	my %features = map { $_ => 1 } @{get_key($file, "kit.features", get_key($file, "kit.subkits", []))};
+	my %features = map { $_ => 1 } @{get_key($file, "kit.features") || get_key($file, "kit.subkits") || []};
 	return $features{$feature};
 }
 

--- a/bin/genesis
+++ b/bin/genesis
@@ -3573,8 +3573,8 @@ sub download_kit_tarball
 	debug "downloaded kit #M{$name}/#C{$version}\n";
 }
 sub validate_kit_files {
-	my ($dir,$meta) = @_;
-	my ($metadata, $label, @errors, @warnings);
+	my ($dir,$is_author) = @_;
+	my ($metadata, @errors, @warnings);
 	if (-d $dir) {
 		for (qw(hooks)) {
 			push @warnings, "$dir/$_ directory does not exist" unless -d "$dir/$_";
@@ -3592,17 +3592,12 @@ sub validate_kit_files {
 		}
 
 		if (-d "$dir/subkits/") {
-			$label = "subkits";
-			push @warnings, "using deprecated 'subkits' subdirectory -- use 'features' instead.";
+			# Once the docs/AUTHORING-KITS.md has been updated, we want to educate
+			# kit authors that the preferred way is to use features instead of
+			# subkits, and that subkits will probably be deprecated in 3.0
+			#push @warnings, "Enhancement: using 'subkits' subdirectory structure has been  -- use 'features' instead."
+			#	if $is_author;
 			for (glob "$dir/subkits/*") {
-				push @errors, "$_/params.yml does not exist" unless -f "$_/params.yml";
-			}
-		}
-		if (-d "$dir/features/") {
-			push @errors, "using both features and subkits subdirectories -- use only features"
-				if $label && $label eq "subkits";
-			$label = "features";
-			for (glob "$dir/features/*") {
 				push @errors, "$_/params.yml does not exist" unless -f "$_/params.yml";
 			}
 		}
@@ -3650,14 +3645,17 @@ sub validate_kit_metadata {
 	my ($group,$label,$not_label);
 	if (exists $meta->{features}) {
 		if (exists $meta->{subkits}) {
-			error "\n#R{ERROR:} Kit contains both 'features' and deprecated 'subkits'.\n";
+			error "\n#R{ERROR:} Kit contains both 'features' and 'subkits'.\n";
 			die $is_author
-				? "Update kit to move deprecated subkits under 'features' and update 'subkit' key to 'feature'\n"
+				? "Update kit to move subkits under 'features' and update 'subkit' key to 'feature'\n"
 				: "Please contact your kit author for a fix.\n";
 		}
 		($group,$label,$not_label) = qw(features feature subkit);
 	} elsif (exists $meta->{subkits}) {
-		error "\n#Y{DEPRECATED:} subkits are deprecated in favour of features.  Please update your kit." if $is_author;
+		# Once the docs/AUTHORING-KITS.md has been updated, we want to educate
+		# kit authors that the preferred way is to use features instead of
+		# subkits, and that subkits will probably be deprecated in 3.0
+		# error "\n#Y{DEPRECATED:} subkits are deprecated in favour of features.  Please update your kit." if $is_author;
 		($group,$label,$not_label) = qw(subkits subkit feature);
 	}
 	if (defined $group) {
@@ -3669,7 +3667,7 @@ sub validate_kit_metadata {
 			}
 		}
 		die($is_author
-			? "\nUpdate kit to used 'features' and 'feature' exclusively\n"
+			? "\nUpdate kit to use 'features' and 'feature' exclusively\n"
 			: "\nPlease contact your kit author for a fix.\n"
 		) if $errored;
 	}
@@ -5751,7 +5749,7 @@ sub {
 		}
 	}
 
-	my $metadata = validate_kit_files($dir);
+	my $metadata = validate_kit_files($dir,1);
 	validate_kit_metadata($options{name},$options{version},$metadata,1);
 
 	my $temp = tempdir(CLEANUP => 1);

--- a/bin/genesis
+++ b/bin/genesis
@@ -932,6 +932,21 @@ sub standalone_environment_yaml_files {
 	return grep { find_key("params.env", $_) } @_;
 }
 
+sub get_env {
+	(my $env = shift) =~ s/\.yml$//;
+	my $file =  $env.".yml";
+	die "Environment file '$file' does not exist!\n" unless -f $file;
+	#die "File '$file' is not a valid environment!\n" unless find_key('params.env',$file);
+	#^ The above breaks tests (t/compile.t) because we were lax in the past
+	#  about what constitutes a deployable env yml file.  If test-env.yml is a
+	#  valid file, with params.env == test-env, can you deploy with file
+	#  test-env-upgrade.yml that changes the kit version but keeps the same 
+	#  params.env??? (Commented out for now)
+	#  we may also want a check such as the following:
+	#die "File '$file' defines a different environment according to its params.env.  Cut and paste error?\n" unless get_key($env,'params.env') eq $env;
+	return $env;
+}
+
 sub get_env_file {
 	my ($env) = @_;
 	$env =~ s/.yml$//;
@@ -5344,6 +5359,7 @@ sub {
 		dry-run
 	/);
 	usage(1) if @_ != 1;
+	my $env = get_env(shift);;
 	check_prereqs;
 
 	if ($options{fix} && $options{recreate}) {
@@ -5355,7 +5371,7 @@ sub {
 		delete $options{'non-interactive'};
 	}
 
-	my $rc = deploy_manifest($_[0], \%options);
+	my $rc = deploy_manifest($env, \%options);
 	exit $rc;
 });
 # }}}
@@ -5816,7 +5832,7 @@ sub {
 		redact!
 	/);
 	usage(1) if @_ != 1;
-	my ($env) = @_;
+	my $env = get_env(shift);;
 	check_prereqs;
 
 	$ENV{REDACT} = $options{'redact'} ? "1" : "";

--- a/t/compiling.t
+++ b/t/compiling.t
@@ -107,12 +107,13 @@ qx(rm -f *.tar.gz *.tgz); # just to be safe
 
 # Run it properly, override name
 ($pass, $rc, $msg) = runs_ok "genesis compile-kit -n kickass --version 0.0.1 --force";
-matches $msg, qr'Warning: . has abnormal contents \(non-fatal\):', "Kit with subkits warning";
-matches $msg, qr/  \* using deprecated 'subkits' subdirectory -- use 'features' instead./, "Abnormal kit directory - using subkits";
+# [When subkits are deprecated] matches $msg, qr'Warning: . has abnormal contents \(non-fatal\):', "Kit with subkits warning";
+# [When subkits are deprecated] matches $msg, qr/  \* using deprecated 'subkits' subdirectory -- use 'features' instead./, "Abnormal kit directory - using subkits";
 matches $msg, qr'Created kickass-0.0.1.tar.gz\n', "Good kit directory - created release.";
 doesnt_match $msg, qr'\nCannot continue.\n', "Abnormal dev kit directory - still can continue";
 $_ = $msg;
-is tr/\n// + !/\n\z/, 5, "Bad dev kit directory -- no unexpected errors or warnings.";
+is tr/\n// + !/\n\z/, 2, "Good dev kit directory -- no unexpected errors or warnings.";
+# [When subkits are deprecated] is tr/\n// + !/\n\z/, 2, "Good dev kit directory -- no unexpected errors or warnings.";
 ok -f "kickass-0.0.1.tar.gz", "genesis compile-test-kit should create the tarball";
 output_ok "tar -tzvf kickass-0.0.1.tar.gz | $tar_parser | sort -k3", <<EOF, "tarball contents are correct";
 drwxr-xr-x 0 kickass-0.0.1/

--- a/t/kit-validation.t
+++ b/t/kit-validation.t
@@ -20,8 +20,6 @@ Generating new environment failures-galore...
 
 Using local development kit (./dev)...
 
-\e[1;33mDEPRECATED:\e[0m subkits are deprecated in favour of features.  Please update your kit.
-
 \e[1;31mERROR:\e[0m The following errors have been encountered validating the dev/latest kit:
  - params.base[0] has an invalid attribute: 'rapams'
  - params.base[0] has an invalid attribute: 'ska'

--- a/t/repos/compile-test-genesis-kit/ci/pipeline.yml
+++ b/t/repos/compile-test-genesis-kit/ci/pipeline.yml
@@ -1,0 +1,18 @@
+---
+#
+# ci/pipeline.yml
+#
+# Pipeline structure file for a Genesis Release pipeline
+#
+# DO NOT MAKE CHANGES TO THIS FILE.  Instead, modify
+# ci/settings.yml and override what needs overridden.
+# This uses spruce, so you have some options there.
+#
+meta:
+  kit:      (( param "Which kit is this pipeline for?" ))
+  name:     (( concat meta.kit "-genesis-kit" ))
+  release:  (( concat meta.kit " Genesis Kit" ))
+  target:   (( param "Please identify the name of the target Concourse CI" ))
+  url:      (( param "Please specify the full url of the target Concourse CI" ))
+  pipeline: (( grab meta.name ))
+

--- a/t/repos/compile-test-genesis-kit/ci/release_notes.md
+++ b/t/repos/compile-test-genesis-kit/ci/release_notes.md
@@ -1,0 +1,3 @@
+# Improvements
+
+- Did stuff

--- a/t/repos/compile-test-genesis-kit/ci/repipe
+++ b/t/repos/compile-test-genesis-kit/ci/repipe
@@ -1,0 +1,12 @@
+#!/bin/bash
+#
+# ci/repipe
+#
+# Script for merging together pipeline configuration files
+# and configuring Concourse.
+
+do-the-magicks() {
+  echo "Poof.  You have a pipeline!"
+}
+
+do-the-magics

--- a/t/repos/compile-test-genesis-kit/ci/settings.yml
+++ b/t/repos/compile-test-genesis-kit/ci/settings.yml
@@ -1,0 +1,6 @@
+---
+meta:
+  kit:     kick-ass
+  release: KickAss Genesis Kit
+  target:  ci
+  url:     https://my.concourse.ci

--- a/t/subkits.t
+++ b/t/subkits.t
@@ -24,8 +24,6 @@ properties:
 
 EOF
 eq_or_diff get_file("$tmp/manifest-errors"), <<EOF, "errors from manifest generated with webdav subkit";
-
-\e[1;33mDEPRECATED:\e[0m subkits are deprecated in favour of features.  Please update your kit.
 EOF
 
 runs_ok "genesis manifest -c cloud.yml use-webdav 2>$tmp/manifest-errors >$tmp/manifest.yml";
@@ -39,28 +37,20 @@ properties:
 
 EOF
 eq_or_diff get_file("$tmp/manifest-errors"), <<EOF, "errors from manifest generated with webdav subkit";
-
-\e[1;33mDEPRECATED:\e[0m subkits are deprecated in favour of features.  Please update your kit.
 EOF
 
 run_fails "genesis manifest -c cloud.yml use-the-wrong-thing >$tmp/errors 2>&1", undef;
 eq_or_diff get_file("$tmp/errors"), <<EOF, "manifest generate fails with an invalid blobstore subkit";
-
-\e[1;33mDEPRECATED:\e[0m subkits are deprecated in favour of features.  Please update your kit.
 No subkit 'magic' found in kit dev/latest.
 EOF
 
 run_fails "genesis manifest -c cloud.yml use-nothing >$tmp/errors 2>&1", undef;
 eq_or_diff get_file("$tmp/errors"), <<EOF, "manifest generate fails without a valid blobstore subkit";
-
-\e[1;33mDEPRECATED:\e[0m subkits are deprecated in favour of features.  Please update your kit.
 You must select a subkit to provide your blobstore. Should be one of 'webdav', 's3'
 EOF
 
 run_fails "genesis manifest -c cloud.yml use-too-many >$tmp/errors 2>&1", undef;
 eq_or_diff get_file("$tmp/errors"), <<EOF, "manifest generate fails with too many blobstore subkits";
-
-\e[1;33mDEPRECATED:\e[0m subkits are deprecated in favour of features.  Please update your kit.
 You selected too many subkits for your blobstore. Should be only one of 'webdav', 's3'
 EOF
 


### PR DESCRIPTION
This are issues that were fixed en-masse in support of or discovered during the move to use genesis metadata in vault to better support BOSH discovery for pipelines (#227). They include:

* Fix default redaction behaviour on manifest and deploy (redacts on pipeline or redirection, doesn't redact from a controlling terminal) .  Still can be manually specified to redact or not.
* Added --dry-run on deploy to match BOSH's deploy --dry-run behaviour.
* Improved execution of subprocesses (phase 1 of issue #228 )
* Improved `has_key` and `get_key` (1d8e0ca)
* -D option is now less noisy: Sets GENESIS_DEBUG instead of DEBUG so you only get Genesis's debug output, not including all the subprocesses (ie spruce).  Setting DEBUG env var prior to calling still results in the full debug effect.
* Ensures the specified env file exists for manifest and deploy actions (Fixes #238)
* Un-deprecates the subkit usage until 'features' are officially released and supported
* Removed ci directory from compiled kits (Fixes #237 )

