### PR TITLE
'genesis new' - choose env from known bosh aliases

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -4729,7 +4729,7 @@ EOF
 
 command("new", <<EOF,
 genesis v$VERSION
-USAGE: genesis new [--vault target] env-name[.yml]
+USAGE: genesis new [--vault target]
 
 OPTIONS
 $GLOBAL_USAGE
@@ -4758,10 +4758,25 @@ sub {
 		secrets!
 		kit|k=s
 	/);
-	usage(1) if @_ != 1;
+	usage(0) if @_ != 0;
 
-	my ($name) = @_;
-	$name =~ s/\.yml$//;
+	use Data::Dumper;
+	my (@bosh_envs, @bosh_envs_with_urls);
+	if (-f $ENV{HOME}."/.bosh/config") {
+		my $bosh_json = decode_json(qx{spruce json \$HOME/.bosh/config});
+		foreach my $env (@{$bosh_json->{environments}}) {
+			push(@bosh_envs, $env->{alias});
+			push(@bosh_envs_with_urls, "$env->{alias} ($env->{url})");
+		}
+	}
+	if (scalar(@bosh_envs) == 0) {
+		explain "Please run `bosh alias-env` to register the available BOSH environments.";
+		exit 1;
+	}
+
+	my $name = prompt_for_choice(clean_heredoc(<<"	  |EOF"), \@bosh_envs, undef, \@bosh_envs_with_urls);
+	  |Choose a BOSH/Genesis environment:
+	  |EOF
 
 	my $err = check_env_name_for_errors($name);
 	die "Invalid environment name '$name': $err\n" if $err;

--- a/bin/genesis
+++ b/bin/genesis
@@ -4729,7 +4729,7 @@ EOF
 
 command("new", <<EOF,
 genesis v$VERSION
-USAGE: genesis new [--vault target]
+USAGE: genesis new [--vault target] [env-name[.yml]]
 
 OPTIONS
 $GLOBAL_USAGE
@@ -4758,25 +4758,30 @@ sub {
 		secrets!
 		kit|k=s
 	/);
-	usage(0) if @_ != 0;
-
-	use Data::Dumper;
-	my (@bosh_envs, @bosh_envs_with_urls);
-	if (-f $ENV{HOME}."/.bosh/config") {
-		my $bosh_json = decode_json(qx{spruce json \$HOME/.bosh/config});
-		foreach my $env (@{$bosh_json->{environments}}) {
-			push(@bosh_envs, $env->{alias});
-			push(@bosh_envs_with_urls, "$env->{alias} ($env->{url})");
+	my $name;
+	if (@_ == 1) {
+		($name) = @_;
+		$name =~ s/\.yml$//;
+	} elsif (@_ == 0) {
+		my (@bosh_envs, @bosh_envs_with_urls);
+		if (-f $ENV{HOME}."/.bosh/config") {
+			my $bosh_json = decode_json(qx{spruce json \$HOME/.bosh/config});
+			foreach my $env (@{$bosh_json->{environments}}) {
+				push(@bosh_envs, $env->{alias});
+				push(@bosh_envs_with_urls, "$env->{alias} ($env->{url})");
+			}
 		}
-	}
-	if (scalar(@bosh_envs) == 0) {
-		explain "Please run `bosh alias-env` to register the available BOSH environments.";
-		exit 1;
+		if (scalar(@bosh_envs) == 0) {
+			explain "Please run `bosh alias-env` to register the available BOSH environments.";
+			exit 1;
+		}
+
+		$name = prompt_for_choice(clean_heredoc("Choose a BOSH/Genesis environment:"), 
+							\@bosh_envs, undef, \@bosh_envs_with_urls);
+	} else {
+		usage(0)
 	}
 
-	my $name = prompt_for_choice(clean_heredoc(<<"	  |EOF"), \@bosh_envs, undef, \@bosh_envs_with_urls);
-	  |Choose a BOSH/Genesis environment:
-	  |EOF
 
 	my $err = check_env_name_for_errors($name);
 	die "Invalid environment name '$name': $err\n" if $err;


### PR DESCRIPTION
Previously the user had to type a label for their genesis/bosh env 
`genesis new some-env` and the subsequent `genesis deploy` would discover
if `some-env` was actually a BOSH environment alias or not.

This PR ensures that the user already has `bosh alias-env` for each environment
by asking the user to choose their `genesis new` from a menu of `bosh envs`.

Output looks like:

```
$ genesis new

Choose a BOSH/Genesis environment:
  1) useast2-prod (10.10.1.4)
  2) useast2-lite (10.10.1.5)

Select choice > useast2-lite (10.10.1.5)
Generating new environment useast2-lite...
```