### PR TITLE
Refactored check_prereqs

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1411,28 +1411,24 @@ sub is_valid_uri {
 	return $components{uri};
 }
 
-sub bosh_cmd {
-	check_prereqs() unless $ENV{GENESIS_BOSH_COMMAND};
-	return $ENV{GENESIS_BOSH_COMMAND};
-}
-sub detect_bosh_version {
-	my ($BOSH2_MIN_VERSION) = @_;
+sub check_bosh_version {
+	my ($min) = @_;
 	my $best = "0.0.0";
 	foreach my $boshcmd (qw(bosh2 boshv2 bosh)) {
 		my $version = Genesis::Run::get("$boshcmd -v 2>&1 | grep version | head -n1");
 		if ($version =~ /version (\S+?)-.*/) {
-			if (new_enough("bosh", $1, $BOSH2_MIN_VERSION)) {
+			if (new_enough("bosh", $1, $min)) {
 				$ENV{GENESIS_BOSH_COMMAND} = $boshcmd;
-				debug "Found BOSH v$1 as '$ENV{GENESIS_BOSH_COMMAND}'";
-				return 1
+				debug "#g{Version $1} of #C{$boshcmd} meets or exceeds minimum of #w{$min}";
+				return ();
 			}
 			$best = $1 if new_enough("bosh", $1, $best); # Track the best we've found for error message
 		}
 	}
 	if ($best eq "0.0.0") {
-		die "Missing `bosh2' - install the BOSH (v2) CLI from #B{https://github.com/cloudfoundry/bosh-cli/releases}\n";
+		return "#R{Missing `bosh2`} - install the BOSH (v2) CLI from #B{https://github.com/cloudfoundry/bosh-cli/releases}";
 	} else {
-		die "BOSH (v2) CLI v${best} is installed, but Genesis requires #R{at least $BOSH2_MIN_VERSION} - upgrade your BOSH CLI, via #B{https://github.com/cloudfoundry/bosh-cli/releases}\n";
+		return "BOSH (v2) CLI v${best} is installed, but Genesis requires #R{at least $min} - upgrade your BOSH CLI, via #B{https://github.com/cloudfoundry/bosh-cli/releases}";
 	}
 }
 
@@ -3222,74 +3218,43 @@ sub new_enough {
 	return 1;
 }
 
+sub check_version {
+	my ($name, $min, $cmd, $from, $regex, $url) = @_;
+	$url ||= "your platform package manager";
+	my $version = Genesis::Run::get({stderr => (($from eq 'stderr') ? "&1 >":"")."/dev/null"}, $cmd);
+	return "#R{Missing `$name`} -- install from #B{$url}" if (!$version || $version =~ /not found/);
+	return if (envset('GENESIS_DEV_MODE') && $version =~ /development/);
+	$version =~ $regex;
+	return "Could not determine version of $name from `#m{$cmd}`: Got '#C{$version}" unless $1 && is_semver($1);
+	if (new_enough($name, $1, $min)) {
+		debug "#g{Version $1} of #C{$name} meets or exceeds minimum of #w{$min}";
+		return;
+	}
+	return "$name v{$1} is installed, but Genesis requires #R{at least $min} -- upgrade via #B{$url}";
+}
+
 sub check_prereqs {
 
 	my %conditions = @_;
 
-	my $SPRUCE_MIN_VERSION = "1.12.0";
-	my $SAFE_MIN_VERSION   = "0.1.8";
-	my $VAULT_MIN_VERSION  = "0.6.0";
-	my $GIT_MIN_VERSION    = "1.8.0";
-	my $BOSH2_MIN_VERSION  = "2.0.1";
+	my $bosh_min_version = "2.0.1";
+	my $reqs = [
+		# Name,     Version, Command,                                Grab      Pattern                  Source
+		["spruce", "1.12.0", "spruce -v",                            'stdout', qr(.*version\s+(\S+).*)i, "https://github.com/geofffranks/spruce/releases"],
+		["safe",    "0.1.8", "safe -v",                              'stderr', qr(safe v(\S+)),          "https://github.com/starkandwayne/safe/releases"],
+		["vault",   "0.6.0", "vault -v",                             'stdout', qr(.*vault v(\S+).*)i,    "https://www.vaultproject.io/downloads.html"],
+		["git",     "1.8.0", "git --version",                        'stdout', qr(.*version\s+(\S+).*)],
+		["jq",        "1.5", "jq --version",                         'stdout', qr(^jq-(\S+)),            "https://stedolan.github.io/jq/download/"],
+		["curl",   "7.30.0", "curl --version 2>/dev/null | head -n1",'stdout', qr(^curl\s+(\S+))]
+	];
 
-	my @errors;
-	my $version;
-
-	# check that we has a spruce
-	$version = Genesis::Run::get({stderr => '/dev/null'}, 'spruce -v');
-	if (!$version || $version =~ s/not found//) {
-		push @errors, "Missing `spruce' - install Spruce from #B{https://github.com/geofffranks/spruce/releases}";
-	} else {
-		unless(envset('GENESIS_DEV_MODE') && $version =~ /development/) {
-			chomp($version); $version =~ s/.*version\s+(\S+).*/$1/i;
-			if (!new_enough("spruce", $version, $SPRUCE_MIN_VERSION)) {
-				push @errors, "Spruce v${version} is installed, but Genesis requires #R{at least $SPRUCE_MIN_VERSION} - upgrade your Spruce, via #B{https://github.com/geofffranks/spruce/releases}";
-			}
-		}
-	}
-
-	# check that we has a safe
-	$version = Genesis::Run::get({stderr => "&1 >/dev/null"}, 'safe -v');
-	if (!$version || $version =~ s/not found//) {
-		push @errors, "Missing `safe' - install Safe from #B{https://github.com/starkandwayne/safe/releases}";
-	} else {
-		unless (envset('GENESIS_DEV_MODE') && $version =~ /development build/) {
-			chomp($version); $version =~ s/^safe v(\S+)/$1/i;
-			if (!new_enough("safe", $version, $SAFE_MIN_VERSION)) {
-				push @errors, "Safe v${version} is installed, but Genesis requires #R{at least $SAFE_MIN_VERSION} - upgrade your Safe, via #B{https://github.com/starkandwayne/safe/releases}";
-			}
-		}
-	}
-
-	# check that we has a vault
-	$version = Genesis::Run::get({stderr => '/dev/null'}, 'vault -v');
-	if (!$version) {
-		push @errors, "Missing `vault' - install Vault from #B{https://www.vaultproject.io/downloads.html}";
-	} else {
-		chomp($version); $version =~ s/.*vault v(\S+).*/$1/i;
-		if (!new_enough("vault", $version, $VAULT_MIN_VERSION)) {
-			push @errors, "Vault v${version} is installed, but Genesis requires #R{at least $VAULT_MIN_VERSION} - upgrade your Vault, via #B{https://www.vaultproject.io/downloads.html}";
-		}
-	}
+	my @errors = grep {$_} map {check_version(@$_)} @$reqs;
 
 	# check that we has a bosh (v2)
-	detect_bosh_version($BOSH2_MIN_VERSION);
+	push @errors, check_bosh_version($bosh_min_version);
 
-	# check that we has a git
-	$version = Genesis::Run::get({stderr => '/dev/null'}, 'git --version');
-	if (!$version || $version =~ s/not found//) {
-		push @errors, "Missing `git' - install git via your platform package manager";
-	} else {
-		chomp($version); $version =~ s/.*version\s+(\S+).*/$1/i;
-		if (!new_enough("git", $version, $GIT_MIN_VERSION)) {
-			push @errors, "Git v${version} is installed, but Genesis requires #R{at least $GIT_MIN_VERSION}";
-		}
-	}
-
-	unless ($conditions{no_repo_needed}) {
-		push @errors, "This command needs to be run from a Genesis v2 deployment repo, or specify one using -C <dir> option"
-			unless in_repo_dir;
-	}
+	push @errors, "This command needs to be run from a Genesis v2 deployment repo, or specify one using -C <dir> option"
+		unless (in_repo_dir || $conditions{no_repo_needed});
 
 	if (@errors) {
 		error "#R{GENESIS PRE-REQUISITES CHECKS FAILED!!}";

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,5 +1,7 @@
 # Bug Fixes
 
+- Now checks for minimum versions of jq (1.5) and curl (7.30.0).
+
 - Support dash / other POSIX-compliant `/bin/sh` implementations
   whenever we call system() or `qx()` to execute things.  We now
   explicitly call bash (in `$PATH`) to get bash semantics.


### PR DESCRIPTION
Extracted out a generic version checker, then made check_prereqs a data-
driven wrapper around that.  This improves the readability and
maintainability, rather than the current copy/paste/modify of the
previous incarnation.  Improved the error messages and added happy-path
debugging so we know what versions were detected.

Added jq and curl to the prereqs to check.