### PR TITLE
fix explain output format bug

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -772,7 +772,7 @@ sub {
 	# let the user know
 	explain("New environment $env->{name} provisioned!");
     explain("\nTo deploy, run this:\n");
-    explain("  #C{genesis deploy '%s'\n\n}", $env->{name});
+    explain("  #C{genesis deploy '%s'}\n\n", $env->{name});
 });
 
 


### PR DESCRIPTION
After running `genesis new`, at the end, it outputs 
```
To deploy, run this:

  #C{genesis deploy 'test'

}
```
It should be 
```
To deploy, run this:

  genesis deploy 'test'
```
This small PR fixed it 