### PR TITLE
Make the cached manifest unpruned

### DIFF
--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -576,7 +576,7 @@ sub deploy {
 
 	# deployment succeeded; update the cache
 	my $manifest_path=$self->path(".genesis/manifests/$self->{name}.yml");
-	$self->write_manifest($manifest_path, redact => 1);
+	$self->write_manifest($manifest_path, redact => 1, prune => 0);
 	debug("written redacted manifest to $manifest_path");
 
 	# track exodus data in the vault


### PR DESCRIPTION
For debugging purposes, it would be helpful to have the full manifest, including meta, params and exodus data.  It will still be redacted for safety reasons.