### PR TITLE
Added pre-deploy hook, pass data to post-deploy hook

### DIFF
--- a/docs/AUTHORING-KITS.md
+++ b/docs/AUTHORING-KITS.md
@@ -426,6 +426,11 @@ The following hooks are currently recognized by Genesis:
   against a deployed environment.  This includes things like
   visiting deployed web user interfaces, logging into APIs, etc.
 
+- `pre-deploy` - Runs prior to a deployment attempt, and serves two purposes:
+	to perform any final validation to see if the deployment can proceed, and
+	to collect data that can be sent to the post-deploy hook for actions that
+	need to take place after deployment.
+
 - `post-deploy` - Runs after a deployment attempts, whether
   successful or not.  This is useful for giving the operator hints
   about their next steps, including what addons to try.

--- a/lib/Genesis/Kit.pm
+++ b/lib/Genesis/Kit.pm
@@ -218,12 +218,15 @@ sub run_hook {
 		$ENV{GENESIS_CLOUD_CONFIG} = $opts{env}->{ccfile} || '';
 
 	} elsif ($hook eq 'pre-deploy') {
-		$ENV{GENESIS_MANIFEST_FILE}      = $opts{manifest};
-		$ENV{GENESIS_PREDEPLOY_DATAFILE} = $opts{datafile};
+		$ENV{GENESIS_PREDEPLOY_DATAFILE} = $opts{env}->tmppath("data");
 
 	} elsif ($hook eq 'post-deploy') {
 		$ENV{GENESIS_DEPLOY_RC} = defined $opts{rc} ? $opts{rc} : 255;
-		$ENV{GENESIS_PREDEPLOY_DATAFILE} = $opts{datafile};
+		if ($opts{data}) {
+			my $fn = $opts{env}->tmppath("data");
+			mkfile_or_fail($fn, $opts{data});
+			$ENV{GENESIS_PREDEPLOY_DATAFILE} = $fn;
+		}
 
 	##### LEGACY HOOKS
 	} elsif ($hook eq 'subkit') {
@@ -267,8 +270,22 @@ sub run_hook {
 		return split(/\s+/, $out);
 	}
 
-	if ($hook eq 'check' || $hook eq 'pre-deploy' ||
-	    ($hook eq 'secrets' && $opts{action} eq 'check')) {
+	if ($hook eq 'pre-deploy') {
+		my $contents;
+		my $fn = $opts{env}->tmppath("data");
+		if ( -f $fn ) {
+			$contents = slurp($fn);
+			unlink $fn;
+		}
+		return (($rc ? 1 : 0), $contents);
+	}
+
+	if ($hook eq 'post-deploy') {
+		unlink $opts{env}->tmppath("data")
+			if -f $opts{env}->tmppath("data");
+	}
+
+	if ($hook eq 'check' || ($hook eq 'secrets' && $opts{action} eq 'check')) {
 		return $rc == 0 ? 1 : 0;
 	}
 


### PR DESCRIPTION
The pre-deploy hook gets given the paths to an unredacted manifest and a file that it can use for output.  This output filename is given to the post-deploy hook if anything was written to the file.

For extra safety, the pre-deploy data filename is unpredictable in size and content.