### PR TITLE
Bump versions for spruce, safe and vault

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -354,9 +354,9 @@ sub check_prereqs {
 	my $bosh_min_version = "2.0.1";
 	my $reqs = [
 		# Name,     Version, Command,                                 Pattern                   Source
-		["spruce", "1.12.0", "spruce -v      2>/dev/null",            qr(.*version\s+(\S+).*)i, "https://github.com/geofffranks/spruce/releases"],
-		["safe",    "0.1.8", "safe -v        2>&1 >/dev/null",        qr(safe v(\S+)),          "https://github.com/starkandwayne/safe/releases"],
-		["vault",   "0.6.0", "vault -v       2>/dev/null",            qr(.*vault v(\S+).*)i,    "https://www.vaultproject.io/downloads.html"],
+		["spruce", "1.14.0", "spruce -v      2>/dev/null",            qr(.*version\s+(\S+).*)i, "https://github.com/geofffranks/spruce/releases"],
+		["safe",    "0.8.1", "safe -v        2>&1 >/dev/null",        qr(safe v(\S+)),          "https://github.com/starkandwayne/safe/releases"],
+		["vault",   "0.9.3", "vault -v       2>/dev/null",            qr(.*vault v(\S+).*)i,    "https://www.vaultproject.io/downloads.html"],
 		["git",     "1.8.0", "git --version  2>/dev/null",            qr(.*version\s+(\S+).*)],
 		["jq",        "1.5", "jq --version   2>/dev/null",            qr(^jq-([\.0-9]+)),       "https://stedolan.github.io/jq/download/"],
 		["curl",   "7.30.0", "curl --version 2>/dev/null | head -n1", qr(^curl\s+(\S+))]


### PR DESCRIPTION
spruce 1.14.0 for better operability with cred_hub variables
safe 0.8.1 for passing in unseal keys
vault 0.9.3 for support for safe local and changed interface