### PR TITLE
Remove old exodus data before submitting new after deploy

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Bug Fixes
+
+Now deletes existing exodus data after successful deployment to ensure
+outdated entries are not kept.

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -599,7 +599,8 @@ sub deploy {
 	debug("setting exodus data in the Vault, for use later by other deployments");
 	$ok = run(
 		{ onfailure => "Successfully deployed, but could not save $self->{name} metadata to the Vault" },
-		'safe', 'set', "secret/exodus/$self->{name}/".$self->{top}->type,
+		'safe', 'rm',  "secret/exodus/$self->{name}/".$self->{top}->type,
+		  '--', 'set', "secret/exodus/$self->{name}/".$self->{top}->type,
 		               map { "$_=$exodus->{$_}" } keys %$exodus);
 
 	return $ok;


### PR DESCRIPTION
Now deletes existing exodus data after successful deployment to ensure outdated entries are not kept.