### PR TITLE
_lookup now supports arrays and array lookup by key/value

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,4 @@
+# Improvements
+
+* Improved lookup command to be able to handle accessing array elements by
+  index or by element hash match (ie `myarray[somekey=specific-value]`)

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -224,7 +224,7 @@ sub _lookup {
 		if (/^(\d+)\]$/) {
 			return $default unless ref($what) eq "ARRAY" && scalar(@$what) > $1;
 			$what = $what->[$1];
-		} elsif (/^([^\[\=]*)=([^\]]*)]$/) {
+		} elsif (/^(.*?)=(.*?)]$/) {
 			return $default unless ref($what) eq "ARRAY";
 			my $found=0;
 			for (my $i = 0; $i < scalar(@$what); $i++) {

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -220,9 +220,25 @@ sub _lookup {
 
 	return $what if $key eq '';
 
-	for (split /\./, $key) {
-		return $default if !exists $what->{$_};
-		$what = $what->{$_};
+	for (split /[\[\.]/, $key) {
+		if (/^(\d+)\]$/) {
+			return $default unless ref($what) eq "ARRAY" && scalar(@$what) > $1;
+			$what = $what->[$1];
+		} elsif (/^([^\[\=]*)=([^\]]*)]$/) {
+			return $default unless ref($what) eq "ARRAY";
+			my $found=0;
+			for (my $i = 0; $i < scalar(@$what); $i++) {
+				if (ref($what->[$i]) eq 'HASH' && defined($what->[$i]{$1}) && ($what->[$i]{$1} eq $2)) {
+					$what = $what->[$i];
+					$found=1;
+					last;
+				}
+			}
+			return $default unless $found;
+		} else {
+			return $default if !exists $what->{$_};
+			$what = $what->{$_};
+		}
 	}
 	return $what;
 }


### PR DESCRIPTION
This now works:

`genesis lookup --deployed my-env 'instance_groups[0].networks[name=public].static_ips'`