### PR TITLE
Support Optional Parameters in kit.yml

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,9 @@
+# Improvements
+
+- Certificates in kit.yml can now have subject alt names that
+  are optional, using the new `${maybe:params.name}` syntax.
+  If `params.name` isn't found in the environment file(s) then
+  that SAN entry will be skipped entirely.
+
+  This allows Kit Authors to generate certificates with
+  user-provided external domains, optionally.

--- a/lib/Genesis/Legacy.pm
+++ b/lib/Genesis/Legacy.pm
@@ -200,7 +200,13 @@ sub process_params {
 
 sub dereference_param {
 	my ($env, $key) = @_;
-	my $val = $env->lookup($key, undef);
+
+	my $default = undef;
+	if ($key =~ m/^maybe:/) {
+		$key =~ s/^maybe://;
+		$default = "";
+	}
+	my $val = $env->lookup($key, $default);
 	die "Unable to resolve '$key' for ".$env->name.". This must be defined in the environment YAML.\n"
 		unless defined $val;
 	return $val;
@@ -291,7 +297,7 @@ sub cert_commands {
 			my $cn = $c->{names}[0];
 			$c->{valid_for} ||= "1y";
 
-			my @name_flags = map {( "--name", dereference_params($_, $options{env}) )} @{$c->{names}};
+			my @name_flags = map {( "--name", $_ )} grep { $_ } map { dereference_params($_, $options{env}) } @{$c->{names}};
 			my @cmd = (
 				"x509",
 				"issue",


### PR DESCRIPTION
The new `${maybe:param}` syntax allows Kit Authors to handle existence
and non-existence of parameters in the operator's environment file(s),
for reasons of certificate subject alternate name generation.

If the `maybe:`'d parameter doesn't exist in the environment file(s),
the empty string is returned (instead of signalling an error), and the
X.509 certificate translation to `safe` calls will omit that `--name`
flag.