### PR TITLE
Fix `genesis embed` for Packed Genesii

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -628,7 +628,7 @@ sub {
 	check_prereqs;
 
 	# FIXME: update .genesis/config with new version info
-	Genesis::Top->new('.')->embed($0);
+	Genesis::Top->new('.')->embed($ENV{GENESIS_CALLBACK_BIN} || $0);
 });
 # }}}
 # genesis init - initialize a new Genesis repository {{{


### PR DESCRIPTION
The GEESE stub sets GENESIS_CALLBACK_BIN so that hooks can call back to
the correct path.  We now also use that for embed, if it is set.

Fixes #294