### PR TITLE
Tweaks to fix Genesis pipeline deployments

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1873,6 +1873,7 @@ sub {
 	# don't set up a bosh alias if we're a create-env based deploy, no need, no data
 	unless ($env->needs_bosh_create_env) {
 		Genesis::BOSH->alias($env->bosh_target);
+		$env->use_cloud_config($ENV{GENESIS_CLOUD_CONFIG});
 	}
   # we need a method of issue tokens with a temporary lifetime, so approle/secret is used
 	vault_auth(vault       => $ENV{VAULT_ADDR},
@@ -1895,8 +1896,6 @@ vaults:
 EOF
 
 	target_vault("ci-deploy");
-
-	$env->use_cloud_config($ENV{GENESIS_CLOUD_CONFIG});
 
 	$env->deploy(redact => !envset('CI_NO_REDACT'))
 		or exit 1;

--- a/bin/genesis
+++ b/bin/genesis
@@ -31,10 +31,7 @@ $Genesis::VERSION = "(development)";
 $Genesis::BUILD = "";
 
 our $USER_AGENT_STRING = "genesis/$Genesis::VERSION";
-$ENV{GENESIS_CALLBACK_BIN} ||= __FILE__;
-if ($ENV{GENESIS_CALLBACK_BIN} !~ m{^/}) {
-	$ENV{GENESIS_CALLBACK_BIN} = "@{[getcwd()]}/$ENV{GENESIS_CALLBACK_BIN}";
-}
+$ENV{GENESIS_CALLBACK_BIN} ||= abs_path(__FILE__);
 
 
 $ENV{HTTPS_PROXY}=$ENV{BOSH_ALL_PROXY} if ($ENV{BOSH_ALL_PROXY});
@@ -1825,8 +1822,6 @@ sub {
 	#   VAULT_ADDR                 - URL of the Vault to use for credentials retrieval
 	#   VAULT_SKIP_VERIFY          - Whether or not to enforce SSL/TLS validation
 	#
-	#   GENESIS_CLOUD_CONFIG       - File path to the cloud config to be used in deployment
-	#
 	#   GIT_BRANCH                 - Name of the git branch to push commits to. post-deploy
 	#   GIT_PRIVATE_KEY            - Private Key to use for pushing commits, post-deploy
 	#
@@ -1850,7 +1845,7 @@ sub {
 	my $env = Genesis::Top->new('.')->load_env($ENV{CURRENT_ENV});
 
 	push(@undefined, grep { !$ENV{$_} }
-		qw/BOSH_ENVIRONMENT BOSH_CA_CERT GENESIS_CLOUD_CONFIG
+		qw/BOSH_ENVIRONMENT BOSH_CA_CERT
 		   BOSH_CLIENT BOSH_CLIENT_SECRET/) unless $env->needs_bosh_create_env;
 
 	if (@undefined) {
@@ -1873,7 +1868,7 @@ sub {
 	# don't set up a bosh alias if we're a create-env based deploy, no need, no data
 	unless ($env->needs_bosh_create_env) {
 		Genesis::BOSH->alias($env->bosh_target);
-		$env->use_cloud_config($ENV{GENESIS_CLOUD_CONFIG});
+		$env->download_cloud_config();
 	}
   # we need a method of issue tokens with a temporary lifetime, so approle/secret is used
 	vault_auth(vault       => $ENV{VAULT_ADDR},

--- a/bin/genesis
+++ b/bin/genesis
@@ -32,6 +32,9 @@ $Genesis::BUILD = "";
 
 our $USER_AGENT_STRING = "genesis/$Genesis::VERSION";
 $ENV{GENESIS_CALLBACK_BIN} ||= __FILE__;
+if ($ENV{GENESIS_CALLBACK_BIN} !~ m{^/}) {
+	$ENV{GENESIS_CALLBACK_BIN} = "@{[getcwd()]}/$ENV{GENESIS_CALLBACK_BIN}";
+}
 
 
 $ENV{HTTPS_PROXY}=$ENV{BOSH_ALL_PROXY} if ($ENV{BOSH_ALL_PROXY});
@@ -1821,6 +1824,8 @@ sub {
 	#   VAULT_SECRET_ID            - Vault SecretID to authenticate to Vault with
 	#   VAULT_ADDR                 - URL of the Vault to use for credentials retrieval
 	#   VAULT_SKIP_VERIFY          - Whether or not to enforce SSL/TLS validation
+  #
+	#   GENESIS_CLOUD_CONFIG       - File path to the cloud config to be used in deployment
 	#
 	#   GIT_BRANCH                 - Name of the git branch to push commits to. post-deploy
 	#   GIT_PRIVATE_KEY            - Private Key to use for pushing commits, post-deploy
@@ -1845,7 +1850,7 @@ sub {
 	my $env = Genesis::Top->new('.')->load_env($ENV{CURRENT_ENV});
 
 	push(@undefined, grep { !$ENV{$_} }
-		qw/BOSH_ENVIRONMENT BOSH_CA_CERT
+		qw/BOSH_ENVIRONMENT BOSH_CA_CERT GENESIS_CLOUD_CONFIG
 		   BOSH_CLIENT BOSH_CLIENT_SECRET/) unless $env->needs_bosh_create_env;
 
 	if (@undefined) {
@@ -1869,11 +1874,29 @@ sub {
 	unless ($env->needs_bosh_create_env) {
 		Genesis::BOSH->alias($env->bosh_target);
 	}
-
+  # we need a method of issue tokens with a temporary lifetime, so approle/secret is used
 	vault_auth(vault       => $ENV{VAULT_ADDR},
 	           skip_verify => envset("VAULT_SKIP_VERIFY"),
 	           role_id     => $ENV{VAULT_ROLE_ID},
 	           secret_id   => $ENV{VAULT_SECRET_ID});
+
+  # write .saferc file so that safe commands execute properly
+	open my $OUT, ">", "$ENV{HOME}/.saferc"
+		or die "Failed to write .saferc information: $!\n";
+
+	print $OUT <<EOF;
+version: 1
+current: ci-deploy
+vaults:
+  ci-deploy:
+    url: $ENV{VAULT_ADDR}
+    token: $ENV{VAULT_TOKEN}
+    skip_verify: @{[envset("VAULT_SKIP_VERIFY") ? "true" : "false"]}
+EOF
+
+	target_vault("ci-deploy");
+
+	$env->use_cloud_config($ENV{GENESIS_CLOUD_CONFIG});
 
 	$env->deploy(redact => !envset('CI_NO_REDACT'))
 		or exit 1;

--- a/bin/genesis
+++ b/bin/genesis
@@ -1824,7 +1824,7 @@ sub {
 	#   VAULT_SECRET_ID            - Vault SecretID to authenticate to Vault with
 	#   VAULT_ADDR                 - URL of the Vault to use for credentials retrieval
 	#   VAULT_SKIP_VERIFY          - Whether or not to enforce SSL/TLS validation
-  #
+	#
 	#   GENESIS_CLOUD_CONFIG       - File path to the cloud config to be used in deployment
 	#
 	#   GIT_BRANCH                 - Name of the git branch to push commits to. post-deploy

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -4,10 +4,8 @@
   checking for HTTP/x.x connections. We've losened it to look for HTTP/x.x or
   HTTP/x.
 
-- Genesis concourse pipelines now properly use the fetched cloud configuration
-  resource in deployments. Previously, pipelines would fail to deploy because
-  the cloud-config resource was not listed as an input.
+- Genesis concourse pipelines now downloads the cloud configuration from the
+  bosh director. Previously, pipelines would fail to deploy because the deploy
+  didn't have a cloud-config to base spruce merges off of.
 
-- Genesis now ensures that `GENESIS_CALLBACK_BIN` is a fully-qualified path. If
-  a relative path is given, it resolves the current working directory and
-  prepends that to the relative path. 
+- Genesis now ensures that `GENESIS_CALLBACK_BIN` is a fully-qualified path.

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,13 @@
+# Bug Fixes
+
+- Accessing a Vault over HTTP/2 now works. Previously our regex was strictly
+  checking for HTTP/x.x connections. We've losened it to look for HTTP/x.x or
+  HTTP/x.
+
+- Genesis concourse pipelines now properly use the fetched cloud configuration
+  resource in deployments. Previously, pipelines would fail to deploy because
+  the cloud-config resource was not listed as an input.
+
+- Genesis now ensures that `GENESIS_CALLBACK_BIN` is a fully-qualified path. If
+  a relative path is given, it resolves the current working directory and
+  prepends that to the relative path. 

--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -221,8 +221,8 @@ pipeline:
     stanza: here
 
   vault:
-    app:    concourse
-    user:   my-name    #defaults to the name of pipeline
+    secret: this-is-a-super-secret
+    role:   this-is-a-vault-app-role
     url:    https://127.0.0.1:8200
     verify: yes
 
@@ -313,13 +313,13 @@ pipeline:
 - **pipeline.vault.url** - The URL of your Vault installation,
   i.e. `https://vault.example.com`.  This is **required**.
 
-- **pipeline.vault.app** - The Application ID, used for Concourse
-  authentication.  Defaults to `concourse`, which is usually
-  sufficient.
+- **pipeline.vault.role** - The AppRole GUID of a given Vault
+  AppRole, used to generate temporary tokens for Vault accessing
+  during deploys. This is **required**.
 
-- **pipeline.vault.user** - The User ID, used for Concourse
-  authentication.  Defaults to the name of the pipeline (i.e.
-  **pipeline.name**) which is usually sifficient.
+- **pipeline.vault.secret** - The secret key GUID of a given Vault
+  AppRole, used to authenticate the AppRole to vault. This is
+  **required**.
 
 - **pipeline.vault.verify** - Instruct Concourse to validate the
   Vault TLS certificate (if using `https://` for your Vault).

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -407,7 +407,7 @@ sub curl {
 	my $in_header;
 	my $line;
 	while ($line = shift @data) {
-		if ($line =~ m/^HTTP\/\d+\.\d+\s+((\d+)(\s+.*)?)$/) {
+		if ($line =~ m/^HTTP\/\d+(?:\.\d)?\s+((\d+)(\s+.*)?)$/) {
 			$in_header = 1;
 			$status_line = $1;
 			$status = $2;

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -1128,6 +1128,7 @@ EOF
 		# don't supply bosh creds if we're create-env, because no one to talk to
 		unless ($E->needs_bosh_create_env) {
 			print $OUT <<EOF;
+            GENESIS_CLOUD_CONFIG: ../$alias-cloud-config/cloud-config.yml
             BOSH_ENVIRONMENT:     $pipeline->{pipeline}{boshes}{$env}{url}
             BOSH_CA_CERT: |
 EOF
@@ -1157,6 +1158,11 @@ EOF
           inputs:
             - { name: $alias-changes } # deploy from latest changes
 EOF
+		unless ($E->needs_bosh_create_env) {
+			print $OUT <<EOF;
+            - { name: $alias-cloud-config } # use latest cloud config to deploy
+EOF
+		}
 		print $OUT <<EOF if $passed;
             - { name: $alias-cache }
 EOF

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -1128,7 +1128,6 @@ EOF
 		# don't supply bosh creds if we're create-env, because no one to talk to
 		unless ($E->needs_bosh_create_env) {
 			print $OUT <<EOF;
-            GENESIS_CLOUD_CONFIG: ../$alias-cloud-config/cloud-config.yml
             BOSH_ENVIRONMENT:     $pipeline->{pipeline}{boshes}{$env}{url}
             BOSH_CA_CERT: |
 EOF
@@ -1158,11 +1157,6 @@ EOF
           inputs:
             - { name: $alias-changes } # deploy from latest changes
 EOF
-		unless ($E->needs_bosh_create_env) {
-			print $OUT <<EOF;
-            - { name: $alias-cloud-config } # use latest cloud config to deploy
-EOF
-		}
 		print $OUT <<EOF if $passed;
             - { name: $alias-cache }
 EOF

--- a/pack
+++ b/pack
@@ -114,6 +114,7 @@ use strict;
 use warnings;
 
 use MIME::Base64 qw/decode_base64/;
+use Cwd qw/abs_path/;
 use FindBin;
 
 # Genesis Extraction and Execution Stub Engine (GEESE)
@@ -134,7 +135,7 @@ die "You have no \$HOME.  Please set one and re-run.\n"
 my $root = "$ENV{HOME}/.geese";
 mkdir $root unless -d $root;
 
-$ENV{GENESIS_CALLBACK_BIN} = __FILE__;
+$ENV{GENESIS_CALLBACK_BIN} = abs_path(__FILE__);
 $ENV{GENESIS_V1_PATH_OVERRIDE} = __FILE__;
 $ENV{GENESIS_V1_BIN} = "$root/genesis-v1";
 


### PR DESCRIPTION
This is an omnibus PR for a few bug fixes discovered while attempting Genesis concourse deployments. It fixes the following:

* HTTP/2 connections to Vault now work properly. Previously our regex was too strict and expected only HTTP/x.x responses. Although authentication to Vault worked perfectly, Genesis would report failure because the regex failed.

* We now ensure the `GENESIS_CALLBACK_BIN` is now a hard path to the `.genesis/bin/genesis` script. If a relative path is given (required for pipeline deploys where we don't know our working directory ahead of time), it resolves the `$CWD` and prepends it to the given path. If a fully qualified path is given already, nothing is altered.

* For genesis pipelines we make an OOB auth call to Vault (without safe). This works great for fetching things from the Vault for manifest merging, however any `safe` calls fail because the configuration isn't properly setup. We now OOB auth to Vault, and write the generated token (and some other data) to `$HOME/.saferc`

* We now link the cloud configuration as an input into the Concourse pipeline if the deployment is a non-proto bosh deployment. Previously, all deployments other than a proto-bosh would fail because they were missing a cloud config. 

First time writing Perl. If my syntax looks weird or I've done something in a roundabout way, let me know. 

Release notes written  🕺
Checked that release notes are not release nodes 🕺
Not wearing a S&W shirt today  🦆
