### PR TITLE
Added cloud_config_needs static_ip, and test

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,0 +1,5 @@
+# Improvements
+
+* Kits can now check that the required number of static_ips in each network
+  are available using the `cloud_config_needs static_ips <network_name>
+  <count>`

--- a/lib/Genesis/Helpers.pm
+++ b/lib/Genesis/Helpers.pm
@@ -199,6 +199,8 @@ export __cloud_config_ok="yes"
 # Support function for cloud_config_needs static_ips
 __ip2dec() {
 	local __acc=0 IFS='.' __b __ip="$1"
+	# this doesn't work if __ip[@] is quoted (using IFS to split on .) - shellcheck warns that it's not quoted
+	# https://github.com/koalaman/shellcheck/wiki/SC2068
 	# shellcheck disable=SC2068
 	for __b in ${__ip[@]} ; do
 		(( __acc = (__acc << 8) + __b ))
@@ -414,9 +416,11 @@ prompt_for() {
 		fi
 		if [[ $__type =~ ^multi- ]] ; then
 			eval "unset $__var; ${__var}=()"
+			# __block is escaped in eval, shellcheck thinks its unused
+			# https://github.com/koalaman/shellcheck/wiki/SC2034
 			# shellcheck disable=SC2034
-			while IFS= read -rd '' block; do
-				eval "${__var}+=( \"\$block\" )"
+			while IFS= read -rd '' __block; do
+				eval "${__var}+=( \"\$__block\" )"
 			done < "$__tmpfile"
 		else
 			eval "$__var=\$(<\"$__tmpfile\")"
@@ -458,6 +462,8 @@ export -f param_entry
 param_comment() {
 	local __line __varname=$1; shift
 	eval "$__varname+=\"\\n\""
+	# __line is escaped in eval, shellcheck thinks its unused
+	# https://github.com/koalaman/shellcheck/wiki/SC2034
 	# shellcheck disable=SC2034
 	for __line in "$@" ; do
 		eval "$__varname+=\"  # \$__line\\n\""

--- a/t/21-hooks.t
+++ b/t/21-hooks.t
@@ -77,8 +77,10 @@ EOF
 }
 
 my $has_shellcheck = !system('command shellcheck -V >/dev/null 2>&1');
-printf STDERR "\n\n\e[33mSKIPPING 'Validate hooks helper script' tests due to missing 'shellcheck' command\e[0m\n\n"
-	unless $has_shellcheck;
+printf STDERR "\n\n\e[33m%s\e[0m\n%s\n\n",
+	"SKIPPING 'Validate hooks helper script' tests due to missing 'shellcheck' command",
+	"See https://github.com/koalaman/shellcheck/blob/master/README.md for installation and usage instructions"
+		unless ($has_shellcheck);
 
 subtest 'Validate hooks helper script' => sub {
 
@@ -128,8 +130,8 @@ subtest 'Validate hooks helper script' => sub {
 			}
 
 			push (@msg, sprintf(
-					"[%s] %s:\n%s\n%s^--- [line %d, column %d]",
-					uc($err->{level}), $err->{message},
+					"[SC%s - %s] %s:\n%s\n%s^--- [line %d, column %d]",
+					$err->{code}, uc($err->{level}), $err->{message},
 					$line,
 					" " x ($coln-1), $linen, $coln
 			));

--- a/t/21-hooks.t
+++ b/t/21-hooks.t
@@ -76,6 +76,69 @@ EOF
 	$stack_scale = $top->load_env('stack-scale');
 }
 
+my $has_shellcheck = !system('command shellcheck -V >/dev/null 2>&1');
+printf STDERR "\n\n\e[33mSKIPPING 'Validate hooks helper script' tests due to missing 'shellcheck' command\e[0m\n\n"
+	unless $has_shellcheck;
+
+subtest 'Validate hooks helper script' => sub {
+
+	plan skip_all => "Cannot validate hooks helper because shellcheck is not installed"
+	unless $has_shellcheck;
+
+	use Genesis::Helpers;
+
+	my $helper_script = $tmp . "/helpers.sh";
+	lives_ok { Genesis::Helpers->write($helper_script); } "Can write the helper script to file";
+	my $out = qx{
+		shellcheck $helper_script  -s bash -f json \\
+		| jq -cr '.[] | select(.level == "error" or .level == "warning")'
+	};
+
+	my @msg = ();
+	if ($out ne "") {
+		my (@lines, $offset);
+		if ($INC{'Genesis/Helpers.pm'}) {
+			open my $handle, '<', $INC{'Genesis/Helpers.pm'};
+			chomp(@lines = <$handle>);
+			close $handle;
+			my $i=0;
+			foreach (@lines) {
+				$i++;
+				if ($_ eq '__DATA__') {
+					$offset = $i;
+					last;
+				}
+			}
+		}
+
+		my $startline = qx(grep -n '^__DATA__\$' "${INC{'Genesis/Helpers.pm'}}" | awk -F: '{print \$1}');
+		foreach (split($/, $out)) {
+			my $err   = decode_json($_);
+			my $linen = $offset + $err->{line};
+			my $coln  = $err->{column};
+			my $line  = $lines[$linen-1];
+			my $i = 0;
+			while ($i < $coln) {
+				if (substr($line,$i,1) eq "\t") {
+					substr($line, $i, 1) = "  "; # replace tab with 2 spaces
+					$i++;
+					$coln -= 6; # realign column (tabs count as 8 spaces in shellcheck)
+				}
+				$i++;
+			}
+
+			push (@msg, sprintf(
+					"[%s] %s:\n%s\n%s^--- [line %d, column %d]",
+					uc($err->{level}), $err->{message},
+					$line,
+					" " x ($coln-1), $linen, $coln
+			));
+		}
+	}
+	ok($out eq "", "$INC{'Genesis/Helpers.pm'} script should not contain any errors or warnings") or
+		diag "\n".join("\n\n", @msg);
+};
+
 subtest 'invalid or nonexistent hooks' => sub {
 	again();
 

--- a/t/README.md
+++ b/t/README.md
@@ -1,0 +1,49 @@
+While Genesis was designed to be distributed with no perl dependencies besides
+a version of perl that was released within the last decade, testing it does
+require some CPAN modules and further configurations.
+
+Furthermore, testing Genesis also requires the same system dependencies on
+spruce, safe, vault, jq, etc that would be required to run in in production:
+namely the same things that the jumpbox boshrelease or script uses.
+
+In order to configure for testing do the following:
+
+On OSX:
+  * `brew tap starkandwayne/cf`
+  * `brew install spruce safe`
+  * `brew install cloudfoundry/tap/bosh-cli` 
+    # alternatively, add the tap and install bosh-cli
+  * `brew install jq`
+  * install install from https://www.vaultproject.io/downloads.html
+
+On Linux:
+  * The most straight-forward method of installing under linux is to install
+    the jumpbox script:
+
+  ```
+  sudo curl -o /usr/local/bin/jumpbox \
+  https://raw.githubusercontent.com/starkandwayne/jumpbox/master/bin/jumpbox
+
+  sudo chmod 0755 /usr/local/bin/jumpbox
+
+  jumpbox system
+
+  jumpbox user # optional
+  ```
+
+  You may also need to install expect with your OS package manager if its not
+  present by default.  For example, on Ubuntu you would issue:
+  `sudo apt install expect`
+
+---
+
+CPAN Modules:
+
+You will need the following cpan modules to run tests:
+
+Expect
+Test::Exception
+Test::Deep
+Test::Differences
+Test::Output
+

--- a/t/README.md
+++ b/t/README.md
@@ -1,5 +1,5 @@
-While Genesis was designed to be distributed with no perl dependencies besides
-a version of perl that was released within the last decade, testing it does
+While Genesis was designed to be distributed with no Perl dependencies besides
+a version of Perl that was released within the last decade, testing it does
 require some CPAN modules and further configurations.
 
 Furthermore, testing Genesis also requires the same system dependencies on

--- a/t/bin/vault
+++ b/t/bin/vault
@@ -21,14 +21,16 @@ case $OSTYPE in
 	;;
 esac
 
-if [[ ! -f t/vaults/vault-${version} ]]; then
-	printf >&2 "\rDownloading Vault ${version} CLI..."
+cmd="t/vaults/vault-${version}-${platform}"
+
+if [[ ! -f "$cmd" ]]; then
+	printf >&2 "\rDownloading Vault ${version} CLI for $platform ..."
 	curl --fail -sLk > t/tmp/archive.zip \
 		https://releases.hashicorp.com/vault/${version}/vault_${version}_${platform}_${arch}.zip \
 		|| bail "\nFAILED - could not download of vault ${version}"
 
 	unzip -d t/tmp t/tmp/archive.zip > /dev/null 2>&1
-	mv t/tmp/vault t/vaults/vault-${version}
+	mv t/tmp/vault "$cmd"
 	printf >&2 "DONE\n\n"
 fi
 
@@ -41,7 +43,7 @@ port=8200
 while lsof -nP -i ":$port" | grep ":$port\s*(LISTEN)" >/dev/null 2>&1 ; do
   [[ $((++port)) -gt 8300 ]] && bail "No free ports available for dev vault server"
 done
-./t/vaults/vault-${version} server -config <(cat <<EOF
+$cmd server -config <(cat <<EOF
 disable_mlock = 1
 listener "tcp" {
   address     = "127.0.0.1:$port"

--- a/t/helper.pm
+++ b/t/helper.pm
@@ -5,6 +5,7 @@ use Cwd ();
 use Config;
 use File::Temp qw/tempdir/;
 use File::Basename qw/dirname/;
+use JSON::PP;
 
 $ENV{PERL5LIB} = "$ENV{PWD}/lib";
 


### PR DESCRIPTION
This adds the ability for kits to specify how many static_ips are needed, which is a better user experience than failing in spruce at manifest build time for each static IP that is missing.  Syntax is `cloud_config_needs static_ips <network_name> <quantity>`.  For example, the following directives from a mock cf-genesis-kit:

```
    cloud_config_needs static_ips $(lookup params.cf_internal_network cf-core) 15
    cloud_config_needs static_ips $(lookup params.cf_edge_network cf-edge) 25
```

might result in the following output:

```
[my-env] running cloud-config and environmental parameter checks...
Errors were encountered in your cloud-config:
 - network cf-core needs 15 static IP addresses, has 10
 - network cf-edge needs 25 static IP addresses, has 15
...
```

Like all cloud_config_needs call usage, this needs to be followed up with a block similar to the following to actually output the error messages and pass/fail:
```
  if check_cloud_config ; then
    describe "  cloud config [#G{OK}]"
  else
    describe "  cloud config [#R{FAILED}]"
    exit 1
  fi
```

Furthermore, the helper bash script that is used by the hooks is now checked with shellcheck, if present.  It has been added to the genesis Docker image in a previous direct-to-master commit.  It will fail on errors or warnings, but pass (and suppress) info and style level messages.  This is done to ensure any new potential errors are caught, but if it is deemed not an error, a directive can be added to the file to bypass that instance in the check (see https://github.com/starkandwayne/genesis/pull/297/files#diff-f57f19e6c402057bc4ea700b4515fdbaR417 for example)
