### PR TITLE
Add the ability for Genesis to automatically extract AppRole from Exodus

### DIFF
--- a/docs/PIPELINES.md
+++ b/docs/PIPELINES.md
@@ -221,8 +221,6 @@ pipeline:
     stanza: here
 
   vault:
-    secret: this-is-a-super-secret
-    role:   this-is-a-vault-app-role
     url:    https://127.0.0.1:8200
     verify: yes
 
@@ -314,12 +312,17 @@ pipeline:
   i.e. `https://vault.example.com`.  This is **required**.
 
 - **pipeline.vault.role** - The AppRole GUID of a given Vault
-  AppRole, used to generate temporary tokens for Vault accessing
-  during deploys. This is **required**.
+  AppRole, used to generate temporary tokens for Vault-accessing
+  during deploys. This field is optional, provided that the
+  `setup-approle` Genesis addon was executed on the targeted
+  Concourse. If you'd prefer to manage your own AppRole and policy,
+  you may fill out this field.
 
 - **pipeline.vault.secret** - The secret key GUID of a given Vault
-  AppRole, used to authenticate the AppRole to vault. This is
-  **required**.
+  AppRole, used to authenticate the AppRole to vault. Like the above
+  field, it is optional provided that the `setup-approle` addon was
+  executed on the targeted Concourse. If you'd prefer to manage your
+  own AppRole and policy, you may fill out this field.
 
 - **pipeline.vault.verify** - Instruct Concourse to validate the
   Vault TLS certificate (if using `https://` for your Vault).

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -381,8 +381,6 @@ sub parse {
 	$P->{pipeline}{unredacted} = yaml_bool($P->{pipeline}{unredacted}, 0);
 
 	# some default values, if the user didn't supply any
-	$P->{pipeline}{vault}{role}   ||= "";
-	$P->{pipeline}{vault}{secret} ||= "";
 	$P->{pipeline}{vault}{verify} = yaml_bool($P->{pipeline}{vault}{verify}, 1);
 
 	$P->{pipeline}{task}{image}   ||= 'starkandwayne/concourse';
@@ -611,8 +609,8 @@ pipeline:
     branch:      master
     private_key: (( param "Please generate an SSH Deployment Key and install it into Github (with write privileges)" ))
   vault:
-    role:   (( vault "secret/exodus/ci/genesis_pipelines:approle_id" ))
-    secret: (( vault "secret/exodus/ci/genesis_pipelines:approle_secret" ))
+    role:   (( vault "secret/exodus/ci/genesis_pipelines:approle-id" ))
+    secret: (( vault "secret/exodus/ci/genesis_pipelines:approle-secret" ))
 EOF
 
 	if ($pipeline->{pipeline}{slack}) {

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -609,8 +609,8 @@ pipeline:
     branch:      master
     private_key: (( param "Please generate an SSH Deployment Key and install it into Github (with write privileges)" ))
   vault:
-    role:   (( vault "secret/exodus/ci/genesis_pipelines:approle-id" ))
-    secret: (( vault "secret/exodus/ci/genesis_pipelines:approle-secret" ))
+    role:   (( vault "secret/exodus/ci/genesis-pipelines:approle-id" ))
+    secret: (( vault "secret/exodus/ci/genesis-pipelines:approle-secret" ))
 EOF
 
 	if ($pipeline->{pipeline}{slack}) {

--- a/lib/Genesis/CI/Legacy.pm
+++ b/lib/Genesis/CI/Legacy.pm
@@ -610,7 +610,9 @@ pipeline:
     repo:        (( param "Please specify the name of the Git repository" ))
     branch:      master
     private_key: (( param "Please generate an SSH Deployment Key and install it into Github (with write privileges)" ))
-
+  vault:
+    role:   (( vault "secret/exodus/ci/genesis_pipelines:approle_id" ))
+    secret: (( vault "secret/exodus/ci/genesis_pipelines:approle_secret" ))
 EOF
 
 	if ($pipeline->{pipeline}{slack}) {
@@ -1119,8 +1121,8 @@ EOF
             CACHE_DIR:            $alias-cache
             GIT_BRANCH:           (( grab pipeline.git.branch ))
             GIT_PRIVATE_KEY:      (( grab pipeline.git.private_key ))
-            VAULT_ROLE_ID:        $pipeline->{pipeline}{vault}{role}
-            VAULT_SECRET_ID:      $pipeline->{pipeline}{vault}{secret}
+            VAULT_ROLE_ID:        (( grab pipeline.vault.role ))
+            VAULT_SECRET_ID:      (( grab pipeline.vault.secret ))
             VAULT_ADDR:           $pipeline->{pipeline}{vault}{url}
             VAULT_SKIP_VERIFY:    ${\(!$pipeline->{pipeline}{vault}{verify})}
             BOSH_NON_INTERACTIVE: true


### PR DESCRIPTION
This goes in hand with https://github.com/genesis-community/concourse-genesis-kit/pull/38 so that operators no longer have to extract AppRole credentials for pipeline setup.