### PR TITLE
Don't ping BOSH when trying to make aliases

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1867,7 +1867,7 @@ sub {
 
 	# don't set up a bosh alias if we're a create-env based deploy, no need, no data
 	unless ($env->needs_bosh_create_env) {
-		Genesis::BOSH->alias($env->bosh_target);
+		Genesis::BOSH->alias(scalar $env->lookup_bosh_target);
 		$env->download_cloud_config();
 	}
   # we need a method of issue tokens with a temporary lifetime, so approle/secret is used
@@ -1994,7 +1994,7 @@ sub {
 	}
 
 	my $env = Genesis::Top->new('.')->load_env($ENV{CURRENT_ENV});
-	Genesis::BOSH->alias($env->bosh_target);
+	Genesis::BOSH->alias(scalar $env->lookup_bosh_target);
 	Genesis::BOSH->run_errand($env->bosh_target, $env->deployment, $ENV{ERRAND_NAME});
 	exit 0;
 });


### PR DESCRIPTION
The dual-purpose "determine the alias and then ping the director" behavior of `$Env->bosh_target` has been split into two functions:

- `$Env->lookup_bosh_target` returns either the alias (scalar context) or the alias and its source (list context), without generating any network traffic or trying to contact BOSH
- `$Env->bosh_target` always contacts BOSH the first time, and then caches the alias, as before.  Internally, it uses `$Env->lookup_bosh_target` to find the alias in the first place.

This is a refactor that should fix issues with CI pipelines during both deploy and errand-running stages.

Fixes #303 and closes #304 (re-impl)