### PR TITLE
Honour ca cert valid_for and names in kit.yml

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -2,3 +2,6 @@
 
 * `genesis deploy` checks presence of secrets prior to trying to build a
   manifest
+
+* CA Certs specified in kits honour `valid_for` and `names` properties.  Names
+  are added as Subject Alternative Names.

--- a/lib/Genesis/Legacy.pm
+++ b/lib/Genesis/Legacy.pm
@@ -280,11 +280,19 @@ sub cert_commands {
 	my $missing_only = ($options{scope}||'') eq 'add';
 	for my $path (sort keys %$certs) {
 		my $rand = sprintf("%09d", rand(1000000000));
+		my $ttl = "1y";
+		my @names = ('--name', "ca.n$rand.$path");
+		if (defined($certs->{$path}{"ca"})) {
+			$ttl = $certs->{$path}{"ca"}{valid_for} || $ttl;
+			push(@names, '--name', $_)
+				for (@{ $certs->{$path}{"ca"}{names} || [] });
+		}
 		my @cmd = (
 			"x509",
 			"issue",
 			"secret/$options{prefix}/$path/ca",
-			"--name", "ca.n$rand.$path",
+			@names,
+			"--ttl" , $ttl,
 			"--ca");
 		push @cmd, "--no-clobber", "--quiet" if !$force_rotate; # All CA certs are considered kept
 		push @cmds, \@cmd;

--- a/t/kits/certificates/kit.yml
+++ b/t/kits/certificates/kit.yml
@@ -28,7 +28,7 @@ certificates:
         - '*.system.${params.base_domain}'
 
     fixed:
-      ca: { valid_for: 1y }
+      ca: { valid_for: 5y }
       server:
         fixed: true
         valid_for: 1y
@@ -37,7 +37,8 @@ certificates:
 
   certs-b:
     auto-generated-certs-b:
-      ca: { valid_for: 1y }
+      ca:
+        names: [ca.asdf.com, 127.1.2.3]
       server:
         valid_for: 4m
         names: [ asdf.com, www.asdf.com ]


### PR DESCRIPTION
Genesis hard-coded the ca cert validity to 1 year and ignored any
provided names, instead using a random name in the form of
`ca.n<random#>.<secret-name>`.  This solution applies the `valid_for`
property, and adds any provided names as Subject Alternative Name
entries, keeping the random name for the CN field to prevent conflict in
browsers due to reuse of CNs with different serial numbers.