### PR TITLE
Fix min version specification, improve validation of kits when compiling

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -1,5 +1,5 @@
 #!/usr/bin/perl
-# vim:ft=perl:noet:ts=4:sts=4:sw=4:fdm=marker
+# vim:ft=perl:noet:ts=2:sts=2:sw=2:fdm=marker:fdl=0
 use strict;
 use warnings;
 
@@ -1295,8 +1295,9 @@ $GLOBAL_USAGE
                 Automatically set if run from inside a genesis deployments directory.
 
   -f, --force   Proceed with compilation even if there are unstaged or uncommitted
-                changes in the working directory.  Normally, genesis will refuse
-                to continue when this happens.
+                changes in the working directory, or if the validation of the contents
+                fails.  Normally, Genesis will refuse to continue when this
+                happens.
 EOF
 sub {
 	my %options;
@@ -1348,7 +1349,7 @@ sub {
 	}
 
 	my $cc = Genesis::Kit::Compiler->new($dir);
-	my $tar = $cc->compile($options{name}, $options{version}, ".")
+	my $tar = $cc->compile($options{name}, $options{version}, ".", force => $options{force})
 		or bail "Unable to compile v$options{version} of $options{name} Genesis Kit.\n";
 
 	explain("Compiled #G{$options{name}} v#C{$options{version}} at $tar");

--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -1,7 +1,21 @@
+# Kit Authorship Improvements
+
+- Improved validation when compiling kits.
+
+  Breaking Change:  `genesis compile-kit` will now error if you are using
+  legacy keywords in your kit.yml, such as `subkits` and `params`.  If you are
+  maintaining a legacy kit and need to compile a new version, you may use the
+  `-f` option to force the compilation, but be warned, this will bypass all
+  the validation.  It is recommended instead to bring your kit up to the
+  latest standards.
+
 # Bug Fixes
 
-* `genesis deploy` checks presence of secrets prior to trying to build a
+- `genesis deploy` checks presence of secrets prior to trying to build a
   manifest
 
-* CA Certs specified in kits honour `valid_for` and `names` properties.  Names
+- CA Certs specified in kits honour `valid_for` and `names` properties.  Names
   are added as Subject Alternative Names.
+
+- Fixed error in minimum Genesis version specification in generated template
+  and validation.

--- a/t/helper.pm
+++ b/t/helper.pm
@@ -219,7 +219,7 @@ sub runs_ok($;$) {
 		return wantarray ? (0, $exit, $err) : 0;
 	}
 	pass $msg;
-	return wantarray ? (1, $exit, $err) : 1;
+	return wantarray ? (1, 0, $err) : 1;
 }
 
 sub run_fails($$;$) {


### PR DESCRIPTION
Update `genesis compile-kit` to:
  - provide `genesis_version_min` instead of the erroneous
    `genesis_min_version` in the scaffold
  - validate that if provided, `genesis_version_min` is semver format
  - validate that if authors is provided, it is a list
  - validate that no invalid top-level keys are specified

Update `genesis` and `Genesis::Kit::Compiler->compile` to allow `-f`
option to force compilation of a kit even if validation would disallow.
(Provides ability to compile legacy kits that no longer pass validation)

Add tests for the above behaviour changes.

Minor formatting and whitespace fixes.