### PR TITLE
Bosh check timeout

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -109,6 +109,9 @@ domain names that can be used as the host.
 - Cleaned up check and deployment interface to move towards a more standardized
   output.
 
+- BOSH connection checks now first check if the host and port are reachable
+  and listening rather than hanging while attempting to connect.
+
 # Kit Authorship Improvements
 
 - Improved validation when compiling kits.

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -611,7 +611,7 @@ sub bosh_target {
 		my ($bosh, $source) = $self->lookup_bosh_target;
 
 		Genesis::BOSH->ping($bosh)
-			or die csprintf("Could not reach BOSH Director '#M{$bosh}'\n  - specified via $source\n\nDid you create an alias and login to it?\n");
+			or bail("\n#R{[ERROR]} Could not connect to BOSH Director '#M{$bosh}'\n  - specified via $source\n");
 		$self->{__bosh_target} = $bosh;
 	}
 

--- a/t/05-bosh.t
+++ b/t/05-bosh.t
@@ -13,8 +13,6 @@ use Genesis;
 sub bosh_runs_as {
 	my ($expect, $output) = @_;
 	$output = $output ? "echo \"$output\"" : "";
-
-
 	fake_bosh(<<EOF);
 $output
 [[ "\$@" == "$expect" ]] && exit 0;
@@ -42,11 +40,13 @@ subtest '_bosh helper magic' => sub {
 
 subtest 'bosh ping' => sub {
 	local $ENV{GENESIS_BOSH_COMMAND};
+	my $director = fake_bosh_director('the-target');
 	bosh_runs_as("-e the-target env");
-	ok Genesis::BOSH->ping('the-target'), "bosh env should ping ok";
+	ok Genesis::BOSH->ping('the-target'), "bosh env on alias should ping ok";
 
 	bosh_runs_as("-e https://127.0.0.1:25555 env");
-	ok Genesis::BOSH->ping('https://127.0.0.1:25555'), "bosh env should ping ok";
+	ok Genesis::BOSH->ping('https://127.0.0.1:25555'), "bosh env on url should ping ok";
+	$director->stop();
 };
 
 subtest 'bosh create-env' => sub {

--- a/t/30-env.t
+++ b/t/30-env.t
@@ -590,6 +590,10 @@ EOF
 
 subtest 'bosh targeting' => sub {
 	local $ENV{GENESIS_BOSH_COMMAND};
+	my ($director1,$director2) = fake_bosh_directors(
+		{alias => 'standalone'},
+		{alias => 'override-me', port => 26666},
+	);
 	fake_bosh;
 
 	my $vault_target = vault_ok;
@@ -624,16 +628,21 @@ EOF
 
 	{
 		$env = $top->load_env('standalone');
-		local $ENV{GENESIS_BOSH_ENVIRONMENT} = "https://127.0.0.86:25555";
+		local $ENV{GENESIS_BOSH_ENVIRONMENT} = "https://127.0.0.1:26666";
 		$env = $top->load_env('standalone'); # reload otherwise its cached by the previous call
-		is $env->bosh_target, "https://127.0.0.86:25555", "the \$GENESIS_BOSH_ENVIRONMENT overrides all";
+		is $env->bosh_target, "https://127.0.0.1:26666", "the \$GENESIS_BOSH_ENVIRONMENT overrides all";
 	}
 
+	$director1->stop();
+	$director2->stop();
 	teardown_vault();
 };
 
 subtest 'cloud_config_and_deployment' => sub{
 	local $ENV{GENESIS_BOSH_COMMAND};
+	my ($director1) = fake_bosh_directors(
+		{alias => 'standalone'},
+	);
 	fake_bosh;
 	my $vault_target = vault_ok;
 	Genesis::Vault->clear_all();
@@ -737,9 +746,9 @@ EOF
 				}
 			}, "exodus data was written by deployment");
 
+	$director1->stop();
 	teardown_vault();
 };
-
 
 subtest 'new env and check' => sub{
 	local $ENV{GENESIS_BOSH_COMMAND};

--- a/t/init.t
+++ b/t/init.t
@@ -13,7 +13,6 @@ my $target_dir;
 my $intended_target;
 my $link_target;
 
-qx(rm -rf t/tmp; mkdir -p t/tmp);
 my $vault_target = vault_ok();    # this changes $HOME to ./t/tmp/home/
 system 'git config --global user.name "CI Testing"';
 system 'git config --global user.email ci@starkandwayne.com';

--- a/t/legacy.t
+++ b/t/legacy.t
@@ -23,7 +23,6 @@ use helper;
 bosh2_cli_ok;
 my ($pass, $rc, $out);
 
-qx(rm -rf t/tmp; mkdir -p t/tmp);
 # Need to run on a packed version to get v1 code
 ($pass, $rc, $out) = runs_ok "GENESIS_PACK_PATH=t/tmp ./pack", "`./pack runs successfully";
 matches($out, qr|bin/genesis syntax OK|, "Genesis compiled correctly");


### PR DESCRIPTION
Uses tcp_listening to check that the BOSH director is listening on the
specified host and port before blindly trying to connect to it.