### PR TITLE
Add the --target if a GENESIS_TARGET_VAULT is set

### DIFF
--- a/lib/Genesis/Helpers.pm
+++ b/lib/Genesis/Helpers.pm
@@ -111,8 +111,8 @@ exodus() {
     __key=$2
     __env=$1
   fi
-  if safe "$GENESIS_TARGET_VAULT" exists "secret/exodus/${__env}:${__key}"; then
-    safe "$GENESIS_TARGET_VAULT" get "secret/exodus/${__env}:${__key}"
+  if safe ${GENESIS_TARGET_VAULT:+--target} "$GENESIS_TARGET_VAULT" exists "secret/exodus/${__env}:${__key}"; then
+    safe ${GENESIS_TARGET_VAULT:+--target} "$GENESIS_TARGET_VAULT" get "secret/exodus/${__env}:${__key}"
   fi
 }
 export -f exodus
@@ -120,7 +120,7 @@ export -f exodus
 # have_exodus_data_for env/type - return true if exodus data exists
 have_exodus_data_for() {
   local __env=${1:?have_exodus_data_for() must provide an environment/type}
-  safe "$GENESIS_TARGET_VAULT" exists "secret/exodus/${__env}"
+  safe ${GENESIS_TARGET_VAULT:+--target} "$GENESIS_TARGET_VAULT" exists "secret/exodus/${__env}"
   return $?
 }
 export -f have_exodus_data_for


### PR DESCRIPTION
When exodus is called with the GENESIS_TARGET_VAULT the command line was missing the `--target` option which confuses safe

```
++ local __env __key
++ __env=hplab/cf
++ __key=autoscaler_enabled
++ [[ -n '' ]]
++ safe https://10.250.4.48 exists secret/exodus/hplab/cf:autoscaler_enabled
Valid commands are:

    ask         Create or update an insensitive configuration value
    auth        Authenticate to the current target
    copy        Copy a secret from one path to another
    curl        Issue arbitrary HTTP requests to the current Vault (for diagnostics)
    delete      Remove one or more path from the Vault
    dhparam     Generate Diffie-Helman key exchange parameters
    env         Print the environment variables for the current target
    exists      Check to see if a secret exists in the Vault
```

We now add `--target` if GENESIS_TARGET_VAULT is set