### PR TITLE
Bump safe v1.1.0, improve safe target behaviour

### DIFF
--- a/bin/genesis
+++ b/bin/genesis
@@ -365,7 +365,7 @@ sub check_prereqs {
 	my $reqs = [
 		# Name,     Version, Command,                                 Pattern                   Source
 		["spruce", "1.14.0", "spruce -v      2>/dev/null",            qr(.*version\s+(\S+).*)i, "https://github.com/geofffranks/spruce/releases"],
-		["safe",    "0.9.9", "safe -v        2>&1 >/dev/null",        qr(safe v(\S+)),          "https://github.com/starkandwayne/safe/releases"],
+		["safe",    "1.1.0", "safe -v        2>&1 >/dev/null",        qr(safe v(\S+)),          "https://github.com/starkandwayne/safe/releases"],
 		["vault",   "0.9.0", "vault -v       2>/dev/null",            qr(.*vault v(\S+).*)i,    "https://www.vaultproject.io/downloads.html"],
 		["git",     "1.8.0", "git --version  2>/dev/null",            qr(.*version\s+(\S+).*)],
 		["jq",        "1.5", "jq --version   2>/dev/null",            qr(^jq-([\.0-9]+)),       "https://stedolan.github.io/jq/download/"],

--- a/lib/Genesis/Env.pm
+++ b/lib/Genesis/Env.pm
@@ -327,7 +327,7 @@ sub exodus_lookup {
 	debug "Exodus data exists, retrieving it and converting to json";
 	my $out;
 	eval {$out = $self->vault->get($path);};
-	bail "Could not get $for exodus data from the Vault" if $@;
+	bail "Could not get $for exodus data from the Vault: $@" if $@;
 
 	my $exodus = _unflatten($out);
 	return _lookup($exodus, $key, $default);

--- a/lib/Genesis/Vault.pm
+++ b/lib/Genesis/Vault.pm
@@ -158,7 +158,7 @@ sub find {
 	@all_vaults = (
 		map {Genesis::Vault->new($_->{url},$_->{name},$_->{verify})}
 		sort {$a->{name} cmp $b->{name}}
-		@{ read_json_from(run("safe targets --json")) }
+		@{ read_json_from(run({envs => {SAFE_TARGET => ""}}, "safe targets --json")) }
 	) unless @all_vaults;
 	my @matches = @all_vaults;
 	for my $quality (keys %filter) {
@@ -179,7 +179,7 @@ sub find_by_target {
 # default - return the default vault (targeted by system) {{{
 sub default {
 	unless ($default_vault) {
-		my $json = read_json_from(run("safe target --json"));
+		my $json = read_json_from(run({envs => {SAFE_TARGET => ""}},"safe target --json"));
 		$default_vault = (Genesis::Vault->find(name => $json->{name}))[0];
 	}
 	return $default_vault;
@@ -247,6 +247,8 @@ sub get {
 		return {};
 	}
 	return $json->{$path} if (ref($json) eq 'HASH') && defined($json->{$path});
+
+	# Safe 1.1.0 is backwards compatible, but leaving this in for futureproofing
 	if (ref($json) eq "ARRAY" and scalar(@$json) == 1) {
 		if ($json->[0]{export_version}||0 == 2) {
 			return $json->[0]{data}{$path}{versions}[-1]{value};

--- a/lib/Genesis/Vault.pm
+++ b/lib/Genesis/Vault.pm
@@ -221,6 +221,7 @@ sub query {
 	$opts->{env} ||= {};
 	$opts->{env}{DEBUG} = "";                 # safe DEBUG is disruptive
 	$opts->{env}{SAFE_TARGET} = $self->{url}; # set the safe target
+	dump_stack();
 	return run($opts, 'safe', @_);
 }
 
@@ -245,7 +246,14 @@ sub get {
 		);
 		return {};
 	}
-	return $json->{$path};
+	return $json->{$path} if (ref($json) eq 'HASH') && defined($json->{$path});
+	if (ref($json) eq "ARRAY" and scalar(@$json) == 1) {
+		if ($json->[0]{export_version}||0 == 2) {
+			return $json->[0]{data}{$path}{versions}[-1]{value};
+		}
+	}
+	bail "Safe version incompatibility - cannot export path $path";
+
 }
 
 # }}}


### PR DESCRIPTION
This started as a bump to safe v1.0.1, which was not backwards compatible with the previous versions of safe when running `export`.  Safe v1.1.0 reversed that, but genesis left in the code to be compatible with both versions if detected.

Furthermore, safe on some systems was complaining when `$SAFE_TARGET` was set while running `safe targets` -- this change explicitly unsets $SAFE_TARGET prior to calling `safe targets`