### PR TITLE
Support env file min_version of genesis

### DIFF
--- a/ci/release_notes.md
+++ b/ci/release_notes.md
@@ -133,7 +133,7 @@ domain names that can be used as the host.
   so Genesis will auto-populate the `params.env` for them, ensuring that any
   reliance on this does not break existing kits.
 
-- Added `new_genesis_config` helper to print the `genesis:` block to standard
+- Added `genesis_config_block` helper to print the `genesis:` block to standard
   output, so it can be redirected into the environment file being constructed
   by the `new` hook.  Use this instead of constructing it yourself to ensure
   future compatability without having to update your kit (further changes in

--- a/lib/Genesis.pm
+++ b/lib/Genesis.pm
@@ -275,7 +275,9 @@ sub by_semver ($$) { # sort block -- needs prototype
 	my @a = semver($a);
 	my @b = semver($b);
 	return 0 unless @a && @b;
-	while (@a) {
+	while (@a || @b) {
+		$a[0] ||= 0;
+		$b[0] ||= 0;
 		return 1 if $a[0] > $b[0];
 		return -1 if $a[0] < $b[0];
 		shift @a;

--- a/lib/Genesis/Helpers.pm
+++ b/lib/Genesis/Helpers.pm
@@ -494,7 +494,8 @@ param_comment() {
 }
 export -f param_comment
 
-new_genesis_config() {
+# Helper to inject new Genesis configuration (v2.6.13+)
+genesis_config_block() {
 	cat<<EOF
 
 genesis:
@@ -505,6 +506,11 @@ EOF
   secrets_path: "$GENESIS_VAULT_PREFIX"
 EOF
 	fi
+	if [[ -n "$GENESIS_MIN_VERSION" ]] ; then
+		cat <<EOF
+  min_version:  "$GENESIS_MIN_VERSION"
+EOF
+	fi
 	echo ""
 }
-export -f new_genesis_config
+export -f genesis_config_block

--- a/lib/Genesis/Kit.pm
+++ b/lib/Genesis/Kit.pm
@@ -184,6 +184,10 @@ sub run_hook {
 
 		$ENV{GENESIS_VAULT_PREFIX} = $ENV{GENESIS_SECRETS_PATH} = $opts{env}->secrets_path;
 
+		if ($hook eq "new") {
+			$ENV{GENESIS_MIN_VERSION} = $self->metadata->{genesis_version_min} || ""
+		}
+
 		unless (grep { $_ eq $hook } qw/new prereqs/) {
 			$ENV{GENESIS_REQUESTED_FEATURES} = join(' ', $opts{env}->features);
 			if ($opts{env}->needs_bosh_create_env) {

--- a/t/21-hooks.t
+++ b/t/21-hooks.t
@@ -177,6 +177,7 @@ kit:
   features: []
 genesis:
   env:   us-west-1-prod
+  min_version: "2.6.0"
   secrets_path: us/west/1/prod/thing
 EOF
 		"[simple] the 'new' hook should populate the env yaml file properly";
@@ -195,6 +196,7 @@ kit:
   features: []
 genesis:
   env: snw-lab-dev
+  min_version: "2.6.0"
   secrets_path: snw/lab/dev/thing
 params:
   GENESIS_KIT_NAME:     dev

--- a/t/src/creator/hooks/new
+++ b/t/src/creator/hooks/new
@@ -16,7 +16,7 @@ kit:
     - bonus
 EOF
 
-new_genesis_config >> "$ymlfile"
+genesis_config_block >> "$ymlfile"
 cat >>"$ymlfile" -- <<EOF
 params:
   static: junk

--- a/t/src/fancy/hooks/new
+++ b/t/src/fancy/hooks/new
@@ -21,7 +21,7 @@ kit:
   version: $GENESIS_KIT_VERSION
   features: []
 EOF
-new_genesis_config >> $root/$env.yml
+genesis_config_block >> $root/$env.yml
 
 cat >> $root/$env.yml <<EOF
 params:

--- a/t/src/simple/hooks/new
+++ b/t/src/simple/hooks/new
@@ -9,5 +9,5 @@ kit:
   version: $GENESIS_KIT_VERSION
   features: []
 EOF
-new_genesis_config >> $root/$env.yml
+genesis_config_block >> $root/$env.yml
 exit 0


### PR DESCRIPTION
Genesis environment files can now specify the minimimum version of
Genesis that is required to read it.  This is automatically populated
when kits use the new `genesis_config_block` helper and specify a
minimum verison required by the kit, or setting `$GENESIS_MIN_VERSION`
prior to calling that helper..  It can also be expicitly stated by
specifying `genesis.min_version` or `params.genesis_version_min` in the
environment file.

Furthermore, the deprecation warning for not using `genesis` block for
the values in `params` that were moved to `genesis` have been delayed to
a future version, so that detection of kit and env depencency checks can
be in the wild for some time.